### PR TITLE
feat: redesign site for april platform narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 Static site extracted from `honua-io/honua-server` (issue #336).
 
 Repository layout:
-- `index.html` - landing page markup
+- `index.html` - homepage and contact form
+- `platform.html` - platform overview
+- `protocols.html` - protocol surface and compatibility story
+- `sdks.html` - SDK and developer entry points
+- `mobile.html` - mobile and field workflow page
+- `pricing.html` - pricing and licensing page
+- `docs.html` - quickstart and docs hub
 - `styles.css` - site styles
 - `assets/` - static assets
 - `_headers` - deployment response headers (CSP, clickjacking, and related security headers)

--- a/docs.html
+++ b/docs.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua Docs | Quickstart, First API Call, and SDK Entry Points</title>
+    <meta
+      name="description"
+      content="Start with Honua quickly: run the server, make a first API call, install an SDK, and jump into deeper docs."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Docs</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="platform.html">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a class="active" href="docs.html" aria-current="page">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Docs</p>
+          <h1>One clean quickstart path beats a vague “read the docs” link.</h1>
+          <p class="page-intro">
+            This page is the minimum docs hub: start the server, make a first request, install one SDK, and then branch into deeper references for protocols, migration, or mobile.
+          </p>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Quickstart</p>
+            <h2>Get from zero to a working request fast.</h2>
+          </div>
+          <article class="card">
+            <p class="card-kicker">Step 1</p>
+            <h3>Run the server</h3>
+            <pre><code>git clone https://github.com/honua-io/honua-server.git
+cd honua-server
+docker compose up -d
+curl http://localhost:8080/healthz/ready</code></pre>
+          </article>
+          <article class="card" style="margin-top: 16px;">
+            <p class="card-kicker">Step 2</p>
+            <h3>Make a first API call</h3>
+            <pre><code>curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=1%3D1&amp;outFields=*&amp;f=json"</code></pre>
+          </article>
+          <article class="card" style="margin-top: 16px;">
+            <p class="card-kicker">Step 3</p>
+            <h3>Install one SDK</h3>
+            <pre><code>npm install @honua/sdk-js</code></pre>
+            <pre><code>import { HonuaClient } from "@honua/sdk-js/honua";
+
+const client = new HonuaClient({ baseUrl: "https://your-honua-server.com" });
+const result = await client.queryFeatures({ serviceId: "parcels", layerId: 0 });</code></pre>
+          </article>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Deeper Paths</p>
+            <h2>Choose the docs lane that matches your goal.</h2>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card card-link">
+              <h3>Platform docs</h3>
+              <p>Deployment, compatibility, standards references, and launch-facing product docs.</p>
+              <a
+                class="text-link"
+                href="https://honua.gitbook.io/honuaio/"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Open platform docs</a
+              >
+            </article>
+            <article class="card card-link">
+              <h3>JavaScript SDK</h3>
+              <p>Honua-first clients, OGC helpers, migration tooling, and compatibility layers.</p>
+              <a
+                class="text-link"
+                href="https://github.com/honua-io/honua-sdk-js"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Open JS SDK repo</a
+              >
+            </article>
+            <article class="card card-link">
+              <h3>.NET SDK</h3>
+              <p>gRPC, admin, geocoding, and enterprise-friendly dependency injection patterns.</p>
+              <a
+                class="text-link"
+                href="https://github.com/honua-io/honua-sdk-dotnet"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Open .NET SDK repo</a
+              >
+            </article>
+            <article class="card card-link">
+              <h3>Python SDK</h3>
+              <p>Data workflows, admin automation, geocoding, and optional gRPC extras.</p>
+              <a
+                class="text-link"
+                href="https://github.com/honua-io/honua-sdk-python"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Open Python SDK repo</a
+              >
+            </article>
+            <article class="card card-link">
+              <h3>Mobile</h3>
+              <p>MAUI, offline GeoPackage sync, forms, and field-ready client workflows.</p>
+              <a
+                class="text-link"
+                href="https://github.com/honua-io/honua-mobile"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Open mobile repo</a
+              >
+            </article>
+            <article class="card card-link">
+              <h3>Migration and MCP</h3>
+              <p>Migration utilities and agent-facing discovery/query tooling for modern integration paths.</p>
+              <a
+                class="text-link"
+                href="https://github.com/honua-io/honua-sdk-js/tree/trunk/mcp"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Open MCP package</a
+              >
+            </article>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Procurement</p>
+          <h2>After the quickstart, buyers ask about licensing.</h2>
+          <p>
+            Once someone sees a successful API call and an SDK install path, the next blockers are almost always pricing, license clarity, and whether the product can scale without seat taxes.
+          </p>
+          <div class="action-row">
+            <a class="button button-primary" href="pricing.html">View Pricing</a>
+            <a class="button button-secondary" href="protocols.html">View Protocols</a>
+            <a class="button button-ghost" href="index.html#contact">Talk to Us</a>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,35 +3,27 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Honua - Modern GIS Infrastructure</title>
+    <title>Honua | Cloud-Native GIS Platform for APIs, SDKs, Mobile, and MCP</title>
     <meta
       name="description"
-      content="Honua is a cloud native GIS server that speaks Esri REST, OGC API, OData, and MVT from one codebase. 530 OGC conformance tests passing. Drop-in compatible with ArcGIS Pro, QGIS, MapLibre, Power BI."
+      content="Honua unifies GeoServices REST, OGC API, OData, vector tiles, gRPC, MCP, JavaScript/.NET/Python SDKs, and mobile field workflows in one cloud-native geospatial platform."
     />
-    <meta property="og:title" content="Modern GIS Infrastructure for the Cloud Era" />
+    <meta property="og:title" content="Honua | Cloud-Native GIS Platform" />
     <meta
       property="og:description"
-      content="A cloud native, open GIS server designed for interoperability, performance, and low-risk modernization. Drop-in compatible with ArcGIS Pro, QGIS, and MapLibre."
+      content="A geospatial platform for APIs, SDKs, mobile, and AI workflows. GeoServices REST, OGC API, OData, gRPC, MCP, and open deployment targets."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://honua.io" />
-    <meta
-      property="og:image"
-      content="https://honua.io/assets/og-image.png"
-    />
-    <meta property="og:image:alt" content="Honua logo on a blue-green background" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
+    <meta property="og:image" content="https://honua.io/assets/og-image.png" />
+    <meta property="og:image:alt" content="Honua logo on a warm editorial background" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Modern GIS Infrastructure for the Cloud Era" />
+    <meta name="twitter:title" content="Honua | Cloud-Native GIS Platform" />
     <meta
       name="twitter:description"
-      content="A cloud native, open GIS server designed for interoperability, performance, and low-risk modernization. Drop-in compatible with ArcGIS Pro, QGIS, and MapLibre."
+      content="Build on GeoServices REST, OGC API, OData, gRPC, MCP, SDKs, and mobile workflows from one platform."
     />
-    <meta
-      name="twitter:image"
-      content="https://honua.io/assets/og-image.png"
-    />
+    <meta name="twitter:image" content="https://honua.io/assets/og-image.png" />
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.google-analytics.com https://honua.io; form-action 'self' https://formsubmit.co; upgrade-insecure-requests"
@@ -45,555 +37,440 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="page">
-      <header class="hero">
-        <nav class="nav">
-          <div class="logo">
-            <img src="assets/honua-logo.png" alt="Honua logo" />
-            <div class="logo-text">
-              <span class="logo-sub">HONUA.IO</span>
-            </div>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">APIs, SDKs, Mobile, MCP</span>
           </div>
-          <div class="nav-links">
-            <a href="#capabilities">Capabilities</a>
-            <a href="#conformance">Conformance</a>
-            <a
-              href="https://honua.gitbook.io/honuaio/"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Docs</a
-            >
-            <a class="nav-cta" href="#contact">Early Access</a>
-          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a class="active" href="index.html" aria-current="page">Home</a>
+          <a href="platform.html">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a href="https://github.com/honua-io/honua-server" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="#contact">Talk to Us</a>
         </nav>
-
-        <div class="hero-grid">
-          <div class="hero-text reveal">
-            <p class="eyebrow">Cloud Native GIS Server</p>
-            <h1>The Modern Alternative to Legacy GIS Servers</h1>
-            <p class="subhead secondary">
-              Serve features, maps, and tiles through
-              <span class="emphasis">six industry standards</span>
-              from one codebase and one PostGIS database, with drop-in compatibility for ArcGIS, OGC, and BI clients.
-              No per-user licensing.
-            </p>
-            <div class="cta-row">
-              <a
-                class="btn primary"
-                href="#contact"
-                >Request Early Access</a
-              >
-              <a
-                class="btn secondary"
-                href="https://honua.gitbook.io/honuaio/devops-guide/infrastructure"
-                target="_blank"
-                rel="noopener noreferrer"
-                >Get Started</a
-              >
-              <a
-                class="btn ghost"
-                href="https://github.com/honua-io/honua-server"
-                target="_blank"
-                rel="noopener noreferrer"
-                >GitHub</a
-              >
-            </div>
-            <div class="meta-list">
-              <span class="meta-label">Built for</span>
-              <span>Organizations modernizing legacy GIS, adopting open standards, and consolidating delivery on cloud-native infrastructure</span>
-            </div>
-          </div>
-          <div class="hero-panel reveal delay-1">
-            <div class="panel-card accent">
-              <h3>Early access program</h3>
-              <p>
-                We're working with early partners to validate migration paths from ArcGIS Server and Enterprise.
-                If you're modernizing GIS infrastructure or expanding standards-based delivery, let's talk.
-              </p>
-              <div class="cta-row" style="margin-bottom: 0">
-                <a
-                  class="btn primary"
-                  href="#contact"
-                  >Talk to Us</a
-                >
-              </div>
-            </div>
-            <div class="panel-card">
-              <h3>Why modernize now</h3>
-              <ul class="bullet-list">
-                <li>Legacy GIS platforms were built for static VM deployments</li>
-                <li>Interoperability demands now span Esri, OGC, and OData clients</li>
-                <li>Open standards mandates are increasing across procurement</li>
-                <li>Teams need phased migration without breaking existing apps</li>
-                <li>Vendor roadmap changes are accelerating modernization timelines</li>
-              </ul>
-            </div>
-          </div>
-        </div>
       </header>
 
-      <div class="logo-banner">
-        <span class="logo-banner__label">DROP-IN COMPATIBLE WITH</span>
-        <div class="logo-banner__logos">
-          <span class="logo-badge">ArcGIS Pro</span>
-          <span class="logo-badge">ArcGIS JS API</span>
-          <span class="logo-badge">Esri SDKs</span>
-          <span class="logo-badge">QGIS</span>
-          <span class="logo-badge">MapLibre</span>
-          <span class="logo-badge">Leaflet</span>
-          <span class="logo-badge">OpenLayers</span>
-          <span class="logo-badge">Power BI</span>
-          <span class="logo-badge">Excel</span>
-          <span class="logo-badge">Tableau</span>
-        </div>
-      </div>
-
-      <div class="diagram-section">
-        <svg viewBox="0 0 850 280" xmlns="http://www.w3.org/2000/svg" width="100%" role="img" aria-label="Architecture diagram showing clients connecting through a load balancer to auto-scaling Honua server instances backed by PostGIS, Redis, and object storage with OpenTelemetry observability">
-          <title>Honua Cloud Native GIS Architecture</title>
-          <defs>
-            <filter id="ds"><feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#0e2433" flood-opacity=".07"/></filter>
-            <marker id="arr" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="6" markerHeight="5" orient="auto"><path d="M0 0L10 4L0 8z" fill="#b0c4cc"/></marker>
-            <marker id="arrt" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="6" markerHeight="5" orient="auto"><path d="M0 0L10 4L0 8z" fill="#1f6f7a"/></marker>
-          </defs>
-          <style>text{font-family:'Manrope','Segoe UI',system-ui,sans-serif}</style>
-
-          <!-- Clients -->
-          <g filter="url(#ds)">
-            <rect x="8" y="18" width="120" height="36" rx="8" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="68" y="41" text-anchor="middle" font-size="11.5" font-weight="600" fill="#0e2433">ArcGIS Pro</text>
-          </g>
-          <g filter="url(#ds)">
-            <rect x="8" y="66" width="120" height="36" rx="8" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="68" y="89" text-anchor="middle" font-size="11.5" font-weight="600" fill="#0e2433">QGIS</text>
-          </g>
-          <g filter="url(#ds)">
-            <rect x="8" y="114" width="120" height="48" rx="8" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="68" y="135" text-anchor="middle" font-size="11.5" font-weight="600" fill="#0e2433">Web Maps</text>
-            <text x="68" y="151" text-anchor="middle" font-size="8.5" fill="#4a6474">MapLibre · Leaflet · Esri JS</text>
-          </g>
-          <g filter="url(#ds)">
-            <rect x="8" y="174" width="120" height="48" rx="8" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="68" y="195" text-anchor="middle" font-size="11.5" font-weight="600" fill="#0e2433">BI Tools</text>
-            <text x="68" y="211" text-anchor="middle" font-size="8.5" fill="#4a6474">Power BI · Excel · Tableau</text>
-          </g>
-
-          <!-- Client to LB arrows -->
-          <line x1="128" y1="36" x2="222" y2="115" stroke="#d3e2e6" stroke-width="1.2" marker-end="url(#arr)"/>
-          <line x1="128" y1="84" x2="222" y2="123" stroke="#d3e2e6" stroke-width="1.2" marker-end="url(#arr)"/>
-          <line x1="128" y1="138" x2="222" y2="133" stroke="#d3e2e6" stroke-width="1.2" marker-end="url(#arr)"/>
-          <line x1="128" y1="198" x2="222" y2="145" stroke="#d3e2e6" stroke-width="1.2" marker-end="url(#arr)"/>
-
-          <!-- Protocol labels -->
-          <text x="168" y="54" font-size="8" font-weight="600" fill="#4a6474">Esri REST</text>
-          <text x="168" y="80" font-size="8" font-weight="600" fill="#4a6474">OGC API</text>
-          <text x="168" y="127" font-size="8" font-weight="600" fill="#4a6474">MVT Tiles</text>
-          <text x="168" y="182" font-size="8" font-weight="600" fill="#4a6474">OData v4</text>
-
-          <!-- Load Balancer -->
-          <g filter="url(#ds)">
-            <rect x="222" y="92" width="108" height="72" rx="10" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="276" y="126" text-anchor="middle" font-size="11.5" font-weight="600" fill="#0e2433">Load Balancer</text>
-            <text x="276" y="142" text-anchor="middle" font-size="8.5" fill="#4a6474">Ingress</text>
-          </g>
-
-          <!-- LB to Platform arrow -->
-          <line x1="330" y1="128" x2="382" y2="128" stroke="#d3e2e6" stroke-width="1.2" marker-end="url(#arr)"/>
-
-          <!-- Honua Platform container -->
-          <rect x="382" y="6" width="242" height="268" rx="14" fill="#dceff2" stroke="#1f6f7a" stroke-width="1" stroke-opacity=".2"/>
-          <text x="503" y="27" text-anchor="middle" font-size="8.5" font-weight="700" fill="#1f6f7a" letter-spacing=".08em">HONUA PLATFORM</text>
-          <text x="503" y="42" text-anchor="middle" font-size="8" fill="#4a6474">K8s · ECS/Fargate · Lambda · ACA · Azure Functions</text>
-
-          <!-- Server instances -->
-          <g filter="url(#ds)">
-            <rect x="400" y="56" width="206" height="42" rx="8" fill="#1f6f7a"/>
-            <text x="503" y="76" text-anchor="middle" font-size="11" font-weight="600" fill="#fff">Honua Server</text>
-            <text x="503" y="90" text-anchor="middle" font-size="8" fill="rgba(255,255,255,.6)">Instance Group A</text>
-          </g>
-          <g filter="url(#ds)">
-            <rect x="400" y="110" width="206" height="42" rx="8" fill="#1f6f7a"/>
-            <text x="503" y="130" text-anchor="middle" font-size="11" font-weight="600" fill="#fff">Honua Server</text>
-            <text x="503" y="144" text-anchor="middle" font-size="8" fill="rgba(255,255,255,.6)">Instance Group B</text>
-          </g>
-
-          <!-- Endpoint pills -->
-          <rect x="392" y="170" width="92" height="18" rx="9" fill="#fff" stroke="#d3e2e6" stroke-width=".8"/>
-          <text x="438" y="183" text-anchor="middle" font-size="7" font-weight="600" fill="#4a6474">FeatureServer / MapServer</text>
-          <rect x="490" y="170" width="50" height="18" rx="9" fill="#fff" stroke="#d3e2e6" stroke-width=".8"/>
-          <text x="515" y="183" text-anchor="middle" font-size="7" font-weight="600" fill="#4a6474">OGC API</text>
-          <rect x="546" y="170" width="52" height="18" rx="9" fill="#fff" stroke="#d3e2e6" stroke-width=".8"/>
-          <text x="572" y="183" text-anchor="middle" font-size="7" font-weight="600" fill="#4a6474">OData v4</text>
-          <rect x="420" y="195" width="36" height="18" rx="9" fill="#fff" stroke="#d3e2e6" stroke-width=".8"/>
-          <text x="438" y="208" text-anchor="middle" font-size="7" font-weight="600" fill="#4a6474">MVT</text>
-          <rect x="462" y="195" width="50" height="18" rx="9" fill="#fff" stroke="#d3e2e6" stroke-width=".8"/>
-          <text x="487" y="208" text-anchor="middle" font-size="7" font-weight="600" fill="#4a6474">Admin</text>
-
-          <!-- Auto-scale indicator -->
-          <text x="503" y="248" text-anchor="middle" font-size="7.5" fill="#1f6f7a" font-weight="500">&#x21D5; Auto-scaling</text>
-
-          <!-- Platform to Infrastructure arrows -->
-          <line x1="606" y1="77" x2="665" y2="38" stroke="#1f6f7a" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#arrt)"/>
-          <text x="644" y="48" font-size="7" font-weight="500" fill="#1f6f7a">OTel</text>
-          <line x1="606" y1="131" x2="665" y2="108" stroke="#d3e2e6" stroke-width="1.2" marker-end="url(#arr)"/>
-          <line x1="606" y1="140" x2="665" y2="190" stroke="#d3e2e6" stroke-width="1.2" marker-end="url(#arr)"/>
-          <line x1="606" y1="144" x2="665" y2="245" stroke="#d3e2e6" stroke-width="1.2" marker-end="url(#arr)"/>
-
-          <!-- Infrastructure -->
-          <g filter="url(#ds)">
-            <rect x="665" y="14" width="170" height="46" rx="8" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="750" y="35" text-anchor="middle" font-size="10.5" font-weight="600" fill="#0e2433">Monitoring &amp; Ops</text>
-            <text x="750" y="50" text-anchor="middle" font-size="8" fill="#4a6474">OpenTelemetry · Prometheus · Grafana</text>
-          </g>
-          <g filter="url(#ds)">
-            <rect x="665" y="84" width="170" height="46" rx="8" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="750" y="105" text-anchor="middle" font-size="10.5" font-weight="600" fill="#0e2433">Redis Cache</text>
-            <text x="750" y="120" text-anchor="middle" font-size="8" fill="#4a6474">Hot Data · Tile Cache</text>
-          </g>
-          <g filter="url(#ds)">
-            <rect x="665" y="168" width="170" height="46" rx="8" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="750" y="189" text-anchor="middle" font-size="10.5" font-weight="600" fill="#0e2433">PostGIS</text>
-            <text x="750" y="204" text-anchor="middle" font-size="8" fill="#4a6474">Primary Database</text>
-          </g>
-          <g filter="url(#ds)">
-            <rect x="665" y="228" width="170" height="40" rx="8" fill="#fff" stroke="#d3e2e6" stroke-width="1.2"/>
-            <text x="750" y="247" text-anchor="middle" font-size="10.5" font-weight="600" fill="#0e2433">Object Storage</text>
-            <text x="750" y="260" text-anchor="middle" font-size="8" fill="#4a6474">S3 · Azure Blob</text>
-          </g>
-        </svg>
-        <div class="diagram-mobile" aria-hidden="true">
-          <h3>Architecture at a glance</h3>
-          <ul class="bullet-list">
-            <li>Clients: ArcGIS Pro, QGIS, web maps, and BI tools</li>
-            <li>Ingress: load balancer routes requests into Honua runtime</li>
-            <li>Runtime: stateless Honua server groups scale horizontally</li>
-            <li>Data plane: PostGIS primary with optional Redis and object storage</li>
-            <li>Ops: OpenTelemetry, Prometheus, and Grafana observability</li>
-          </ul>
-        </div>
-      </div>
-
       <main>
-        <section id="conformance" class="section highlight reveal delay-2">
-          <div class="section-header">
-            <h2>530 OGC Conformance Tests. 100% Pass Rate.</h2>
-            <p>Honua is tested against official OGC CITE conformance suites. These aren't internal tests &mdash; they're the same certification suites used by standards bodies worldwide.</p>
+        <section class="hero hero-home">
+          <div class="hero-copy">
+            <p class="eyebrow">April 1 Platform Goal</p>
+            <h1>Compatibility for migration. gRPC for apps. MCP for agents.</h1>
+            <p class="lede">
+              Honua lets teams keep ArcGIS-style and standards-based clients working while adding two newer rails:
+              <strong>`gRPC`</strong> for high-throughput app and mobile workflows, and <strong>`MCP`</strong> for
+              agent-native discovery and query workflows. One cloud-native platform, one operational model, no
+              per-user fees or protocol taxes.
+            </p>
+            <div class="action-row">
+              <a class="button button-primary" href="protocols.html">See the Protocol Story</a>
+              <a class="button button-secondary" href="docs.html">Start with Docs</a>
+              <a class="button button-ghost" href="pricing.html">See Licensing</a>
+            </div>
+            <div class="pill-row" aria-label="Launch surface">
+              <span class="pill">GeoServices REST</span>
+              <span class="pill">OGC API</span>
+              <span class="pill">OData v4</span>
+              <span class="pill">gRPC</span>
+              <span class="pill">MCP</span>
+              <span class="pill">JavaScript / .NET / Python</span>
+              <span class="pill">Mobile SDK</span>
+            </div>
+            <div class="callout hero-callout">
+              Migration compatibility is the on-ramp. `gRPC` and `MCP` are the forward edge.
+            </div>
           </div>
-          <div class="stats-grid">
-            <div class="stat-card">
-              <span class="stat-number">137/137</span>
-              <span class="stat-label">OGC API Features</span>
-              <span class="stat-detail">Parts 1, 2 &amp; 3</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-number">227/227</span>
-              <span class="stat-label">WMS 1.3</span>
-              <span class="stat-detail">Full CITE suite</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-number">118/118</span>
-              <span class="stat-label">WMTS 1.0</span>
-              <span class="stat-detail">Full CITE suite</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-number">16/16</span>
-              <span class="stat-label">OGC API Tiles</span>
-              <span class="stat-detail">7 conformance classes</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-number">32/32</span>
-              <span class="stat-label">OGC API Maps</span>
-              <span class="stat-detail">Full conformance</span>
-            </div>
+
+          <div class="hero-stack">
+            <article class="surface-card surface-card-primary">
+              <p class="surface-label">Launch Narrative</p>
+              <h2>Three rails, one platform.</h2>
+              <p>
+                Compatibility keeps migrations low-risk. `gRPC` makes apps and mobile feel modern. `MCP` opens the
+                platform to coding agents and assistants.
+              </p>
+            </article>
+            <article class="surface-card">
+              <p class="surface-label">Why teams switch</p>
+              <ul class="bullet-list">
+                <li>Replace brittle legacy GIS stacks without breaking existing clients.</li>
+                <li>Adopt open standards and typed SDKs while preserving ArcGIS and OGC entry points.</li>
+                <li>Move app, mobile, and agent workflows onto `gRPC` and `MCP` instead of keeping everything trapped in legacy REST patterns.</li>
+              </ul>
+            </article>
           </div>
         </section>
 
-        <section id="capabilities" class="section reveal delay-3">
-          <div class="section-header">
-            <h2>One Server. Six Standards.</h2>
-            <p>Publish once from PostGIS. Consume through whichever protocol your clients need. No ETL, no sync, no duplication.</p>
+        <section class="section stat-section">
+          <div class="section-heading">
+            <p class="eyebrow">Platform Snapshot</p>
+            <h2>The site should reflect the whole platform surface, not one repo.</h2>
           </div>
-          <div class="grid three">
-            <div class="card">
-              <h3>GeoServices REST</h3>
-              <p class="card-subtitle">FeatureServer, MapServer, ImageServer, Geometry Service</p>
-              <ul class="bullet-list">
-                <li>23 FeatureServer operations (query, edits, attachments, related records, replicas, domains, statistics)</li>
-                <li>8 MapServer operations (export, identify, find, legend, query, tiles)</li>
-                <li>9 Geometry Service operations (buffer, simplify, project, intersect, union, clip, difference, area, length)</li>
-                <li>Batch edits via applyEdits and append</li>
-              </ul>
-              <p class="note">ArcGIS Pro, ArcGIS JS, and Esri SDK apps connect without code changes.</p>
-            </div>
-            <div class="card">
-              <h3>OGC API Features</h3>
-              <p class="card-subtitle">CITE certified &mdash; 137/137 tests</p>
-              <ul class="bullet-list">
-                <li>Collections, items, queryables, transactions (create/replace/patch/delete)</li>
-                <li>CQL2 filtering: 10 spatial, 14 temporal, 4 array predicates, 32+ functions</li>
-                <li>Multi-CRS support with Content-Crs headers</li>
-                <li>GeoJSON, JSON, HTML output</li>
-              </ul>
-              <p class="note">QGIS, OpenLayers, and any OGC-compliant client.</p>
-            </div>
-            <div class="card">
-              <h3>OGC API Tiles &amp; Maps</h3>
-              <p class="card-subtitle">CITE certified &mdash; 48/48 tests</p>
-              <ul class="bullet-list">
-                <li>Vector tiles (MVT) and raster tile output</li>
-                <li>OGC API Maps for server-rendered images (PNG, JPEG, TIFF)</li>
-                <li>Styled maps and map tiles per collection</li>
-              </ul>
-              <p class="note">MapLibre, Leaflet, and OGC tile clients.</p>
-            </div>
-            <div class="card">
-              <h3>WMS 1.3 &amp; WMTS 1.0</h3>
-              <p class="card-subtitle">CITE certified &mdash; 345/345 tests</p>
-              <ul class="bullet-list">
-                <li>GetCapabilities, GetMap, GetFeatureInfo (WMS)</li>
-                <li>GetCapabilities, GetTile, GetFeatureInfo (WMTS)</li>
-                <li>KVP and RESTful bindings</li>
-              </ul>
-              <p class="note">Legacy OGC clients, INSPIRE/SDI compliance, QGIS WMS/WMTS layers.</p>
-            </div>
-            <div class="card">
-              <h3>OData v4</h3>
-              <p class="card-subtitle">Enterprise BI integration</p>
-              <ul class="bullet-list">
-                <li>$filter, $select, $orderby, $apply, $batch, $search, $expand</li>
-                <li>Spatial functions (geo.distance, geo.intersects)</li>
-                <li>Aggregation, change tracking ($deltatoken), batch operations</li>
-              </ul>
-              <p class="note">Power BI, Excel, Tableau, SAP &mdash; no plugins required.</p>
-            </div>
-            <div class="card">
-              <h3>Vector Tiles</h3>
-              <p class="card-subtitle">PostGIS-native MVT</p>
-              <ul class="bullet-list">
-                <li>ST_AsMVT tile generation at /tiles/{layer}/{z}/{x}/{y}.mvt</li>
-                <li>TileJSON metadata for client configuration</li>
-                <li>Auto-generated MapLibre GL styles</li>
-              </ul>
-              <p class="note">MapLibre GL JS, Leaflet, Mapbox GL &mdash; fast vector rendering.</p>
-            </div>
+          <div class="stat-grid">
+            <article class="stat-card">
+              <span class="stat-title">Protocols</span>
+              <p>GeoServices REST, OGC API, OData v4, vector tiles, WMS, WMTS, plus `gRPC` and `MCP` as the modern integration rails.</p>
+            </article>
+            <article class="stat-card">
+              <span class="stat-title">Developer Surface</span>
+              <p>JavaScript, .NET, Python, migration tooling, and an MCP server package for agent workflows.</p>
+            </article>
+            <article class="stat-card">
+              <span class="stat-title">Mobile</span>
+              <p>.NET MAUI-first field foundation with GeoPackage offline storage, forms, sync, and gRPC-first transport.</p>
+            </article>
+            <article class="stat-card">
+              <span class="stat-title">Licensing</span>
+              <p>No per-user fees, no protocol gating, no SDK tax. The server runtime is ELv2, while official SDKs, mobile tooling, and site assets are Apache 2.0.</p>
+            </article>
           </div>
         </section>
 
-        <section id="who" class="section reveal delay-3">
-          <div class="section-header">
-            <h2>Who This Is For</h2>
-          </div>
-          <div class="grid three">
-            <div class="card highlight-card">
-              <h3>Mandated open standards</h3>
-              <p>INSPIRE, FAIR data, or procurement requirements demand OGC-compliant services. You need certified conformance, not partial support.</p>
-              <p class="note">530 OGC conformance tests passing. 100% pass rate across all five CITE suites.</p>
-            </div>
-            <div class="card highlight-card">
-              <h3>Operating efficiently at any scale</h3>
-              <p>You need infrastructure that handles both burst traffic and quiet periods without re-architecting your services.</p>
-              <p class="note">Stateless runtime, horizontal scale, and optional serverless deployment let you match platform shape to workload shape.</p>
-            </div>
-            <div class="card highlight-card">
-              <h3>Navigating licensing and platform shifts</h3>
-              <p>Commercial licensing and roadmap changes can force rushed decisions. You need continuity for current clients while reducing long-term lock-in.</p>
-              <p class="note">Honua serves FeatureServer and MapServer patterns your ArcGIS clients already understand, with no per-user licensing.</p>
-            </div>
-          </div>
-        </section>
-
-        <section id="odata" class="section highlight reveal delay-3">
-          <div class="section-header">
-            <h2>Treat Spatial Data like Business Data</h2>
-            <p>
-              Stop locking data in spatial silos. Native OData support means your layers work instantly
-              in Excel, Power BI, and SAP &mdash; no plugins required.
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Architecture</p>
+            <h2>The diagram should explain why Honua is different.</h2>
+            <p class="section-copy">
+              Compatibility gets a team in the door. The deeper innovation is the layered access model: compatibility protocols for migration, gRPC for high-throughput application and mobile paths, and MCP for agent-native discovery and query workflows.
             </p>
           </div>
-          <div class="grid two">
-            <div class="card highlight-card">
-              <h3>Enable</h3>
-              <ul class="bullet-list">
-                <li>View and edit in Excel</li>
-                <li>Power BI and Tableau connectivity</li>
-                <li>ERP and asset management integration</li>
-                <li>Analytics pipelines</li>
-                <li>Low-code platforms</li>
-                <li>MCP server support for AI assistants and agent workflows</li>
-              </ul>
-            </div>
-            <div class="card">
-              <p>Transform GIS into a core component of your data platform &mdash; not a silo.</p>
-              <p class="note">
-                OData v4 endpoints, including spatial functions, aggregation, batch operations, and edit workflows, are built in and designed for
-                enterprise tooling.
+          <div class="diagram-shell">
+            <svg class="platform-diagram" viewBox="0 0 1140 620" role="img" aria-label="Diagram showing legacy clients, modern apps, mobile apps, and AI agents connecting to Honua through compatibility protocols, gRPC, and MCP">
+              <defs>
+                <linearGradient id="inkPanel" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#14252c" />
+                  <stop offset="100%" stop-color="#203b44" />
+                </linearGradient>
+                <linearGradient id="mintPanel" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#dff4ee" />
+                  <stop offset="100%" stop-color="#eef8f4" />
+                </linearGradient>
+                <linearGradient id="orangePanel" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#fff0e6" />
+                  <stop offset="100%" stop-color="#fff8f2" />
+                </linearGradient>
+                <marker id="arrowInk" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M0 0L10 5L0 10z" fill="#37525d" />
+                </marker>
+                <marker id="arrowAccent" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M0 0L10 5L0 10z" fill="#157c68" />
+                </marker>
+                <marker id="arrowSpot" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M0 0L10 5L0 10z" fill="#eb6f2f" />
+                </marker>
+              </defs>
+
+              <rect x="0" y="0" width="1140" height="620" rx="30" fill="#fffaf3" />
+
+              <text x="64" y="72" class="diagram-title">Client surfaces</text>
+              <rect x="54" y="102" width="220" height="84" rx="20" class="diagram-node diagram-node-light" />
+              <text x="80" y="136" class="diagram-node-title">Legacy GIS clients</text>
+              <text x="80" y="164" class="diagram-node-copy">ArcGIS Pro, ArcGIS JS, Esri SDK apps, QGIS</text>
+
+              <rect x="54" y="210" width="220" height="84" rx="20" class="diagram-node diagram-node-light" />
+              <text x="80" y="244" class="diagram-node-title">Data and BI tools</text>
+              <text x="80" y="272" class="diagram-node-copy">Power BI, Excel, Tableau, ERP, low-code</text>
+
+              <rect x="54" y="318" width="220" height="84" rx="20" class="diagram-node diagram-node-highlight" />
+              <text x="80" y="352" class="diagram-node-title">Modern apps and mobile</text>
+              <text x="80" y="380" class="diagram-node-copy">Web apps, services, MAUI field apps, sync workers</text>
+
+              <rect x="54" y="426" width="220" height="84" rx="20" class="diagram-node diagram-node-spot" />
+              <text x="80" y="460" class="diagram-node-title">AI agents and assistants</text>
+              <text x="80" y="488" class="diagram-node-copy">Coding agents, copilots, analyst assistants, automations</text>
+
+              <text x="344" y="72" class="diagram-title">Access rails</text>
+              <rect x="324" y="102" width="222" height="118" rx="22" class="diagram-panel diagram-panel-neutral" />
+              <text x="354" y="138" class="diagram-panel-title">Compatibility layer</text>
+              <text x="354" y="168" class="diagram-panel-copy">GeoServices REST</text>
+              <text x="354" y="193" class="diagram-panel-copy">OGC API, WMS, WMTS, OData, MVT</text>
+
+              <rect x="324" y="246" width="222" height="118" rx="22" class="diagram-panel diagram-panel-accent" />
+              <text x="354" y="282" class="diagram-panel-title">gRPC innovation rail</text>
+              <text x="354" y="312" class="diagram-panel-copy">Binary transport for app, SDK, and mobile paths</text>
+              <text x="354" y="337" class="diagram-panel-copy">Unary open surface, streaming scale path</text>
+
+              <rect x="324" y="390" width="222" height="118" rx="22" class="diagram-panel diagram-panel-spot" />
+              <text x="354" y="426" class="diagram-panel-title">MCP innovation rail</text>
+              <text x="354" y="456" class="diagram-panel-copy">Discovery, schema inspection, filtered query workflows</text>
+              <text x="354" y="481" class="diagram-panel-copy">Agent-native access to the geospatial platform</text>
+
+              <text x="622" y="72" class="diagram-title">Honua platform</text>
+              <rect x="600" y="102" width="304" height="408" rx="28" fill="url(#inkPanel)" />
+              <text x="634" y="146" class="diagram-platform-title">Honua runtime + control plane</text>
+              <text x="634" y="182" class="diagram-platform-copy">Multi-protocol server runtime</text>
+              <text x="634" y="210" class="diagram-platform-copy">Admin API and admin UI</text>
+              <text x="634" y="238" class="diagram-platform-copy">SDK compatibility contracts</text>
+              <text x="634" y="266" class="diagram-platform-copy">Migration tooling and MCP package</text>
+              <text x="634" y="294" class="diagram-platform-copy">Mobile sync, forms, and offline workflows</text>
+              <rect x="632" y="330" width="236" height="52" rx="16" class="diagram-chip diagram-chip-accent" />
+              <text x="654" y="362" class="diagram-chip-title">gRPC differentiates app and mobile performance</text>
+              <rect x="632" y="398" width="236" height="52" rx="16" class="diagram-chip diagram-chip-spot" />
+              <text x="654" y="430" class="diagram-chip-title">MCP differentiates the agent integration layer</text>
+
+              <text x="946" y="72" class="diagram-title">Backing systems</text>
+              <rect x="924" y="102" width="164" height="84" rx="20" class="diagram-node diagram-node-light" />
+              <text x="948" y="136" class="diagram-node-title">PostGIS + storage</text>
+              <text x="948" y="164" class="diagram-node-copy">Core data and persistence</text>
+
+              <rect x="924" y="210" width="164" height="84" rx="20" class="diagram-node diagram-node-light" />
+              <text x="948" y="244" class="diagram-node-title">Cloud targets</text>
+              <text x="948" y="272" class="diagram-node-copy">Docker, K8s, AWS, Azure, serverless</text>
+
+              <rect x="924" y="318" width="164" height="84" rx="20" class="diagram-node diagram-node-light" />
+              <text x="948" y="352" class="diagram-node-title">Observability</text>
+              <text x="948" y="380" class="diagram-node-copy">OpenTelemetry, metrics, health, logs</text>
+
+              <line x1="274" y1="144" x2="324" y2="144" class="diagram-line" marker-end="url(#arrowInk)" />
+              <line x1="274" y1="252" x2="324" y2="158" class="diagram-line" marker-end="url(#arrowInk)" />
+              <line x1="274" y1="360" x2="324" y2="304" class="diagram-line-accent" marker-end="url(#arrowAccent)" />
+              <line x1="274" y1="468" x2="324" y2="448" class="diagram-line-spot" marker-end="url(#arrowSpot)" />
+
+              <line x1="546" y1="160" x2="600" y2="188" class="diagram-line" marker-end="url(#arrowInk)" />
+              <line x1="546" y1="304" x2="600" y2="304" class="diagram-line-accent" marker-end="url(#arrowAccent)" />
+              <line x1="546" y1="448" x2="600" y2="420" class="diagram-line-spot" marker-end="url(#arrowSpot)" />
+
+              <line x1="904" y1="188" x2="924" y2="144" class="diagram-line" marker-end="url(#arrowInk)" />
+              <line x1="904" y1="304" x2="924" y2="252" class="diagram-line" marker-end="url(#arrowInk)" />
+              <line x1="904" y1="420" x2="924" y2="360" class="diagram-line" marker-end="url(#arrowInk)" />
+            </svg>
+          </div>
+          <div class="note-grid" style="margin-top: 18px;">
+            <article class="note-card">
+              <h3>Compatibility is the entry wedge</h3>
+              <p>GeoServices REST, OGC API, OData, WMS, WMTS, and tiles keep migration low-risk and let teams preserve existing clients.</p>
+            </article>
+            <article class="note-card">
+              <h3>gRPC and MCP are the forward wedge</h3>
+              <p>`gRPC` is the fast path for apps and mobile. `MCP` is the safe path for agents. Those two rails are what make Honua feel contemporary rather than merely compatible.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Commercial Model</p>
+            <h2>The pricing story should land on the homepage.</h2>
+            <p class="section-copy">
+              Visitors should understand the economic shape immediately: no seat tax, no protocol tax, and no need to buy separate client access just to use the platform.
+            </p>
+          </div>
+          <div class="mini-grid">
+            <article class="note-card">
+              <h3>No seat pricing</h3>
+              <p>Adding analysts, viewers, or field operators should not force another licensing negotiation.</p>
+            </article>
+            <article class="note-card">
+              <h3>No protocol or SDK add-ons</h3>
+              <p>GeoServices REST, OGC API, OData, SDKs, and the mobile story belong in the product, not behind extra fees.</p>
+            </article>
+            <article class="note-card">
+              <h3>Pay for depth, not permission</h3>
+              <p>Commercial tiers should map to distributed runtime capability, governance, support, and enterprise readiness.</p>
+            </article>
+            <article class="note-card">
+              <h3>Clear license split</h3>
+              <p>The server runtime is ELv2. Official SDKs, mobile tooling, and public collateral are Apache 2.0.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">What Ships Together</p>
+            <h2>The April story is a platform story.</h2>
+            <p class="section-copy">
+              The homepage needs to make the product legible in one scan: what runs, how you integrate, how you migrate,
+              how you deploy, and how licensing works.
+            </p>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card">
+              <p class="card-kicker">Server Runtime</p>
+              <h3>Multi-protocol geospatial runtime</h3>
+              <p>
+                One PostGIS-backed core serving FeatureServer, MapServer, ImageServer, Geometry Service, OGC API,
+                OData, MVT, WMS, and WMTS.
               </p>
-            </div>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Developer Experience</p>
+              <h3>SDKs and quickstarts</h3>
+              <p>
+                Typed SDKs for JavaScript, .NET, and Python with migration tooling, quickstarts, release automation,
+                and compatibility guidance.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Mobile</p>
+              <h3>Field workflows without vendor lock-in</h3>
+              <p>
+                Mobile SDK surfaces cover offline GeoPackage sync, forms, background upload, and gRPC-first feature access.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">AI and Agents</p>
+              <h3>MCP belongs on the front page</h3>
+              <p>
+                MCP is a first-class part of the platform story for discovery, schema inspection, query workflows, and
+                agent integration.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Migration</p>
+              <h3>Esri and GeoServer replacement lane</h3>
+              <p>
+                The public narrative should center migration proof: compatibility, standards, pricing clarity, and staged adoption.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Operations</p>
+              <h3>Cloud-native deployment choices</h3>
+              <p>
+                Docker, Kubernetes, AWS, Azure, and serverless targets stay visible because deploy flexibility is part of the product value.
+              </p>
+            </article>
           </div>
         </section>
 
-        <section id="modernize" class="section reveal delay-3">
-          <div class="section-header">
-            <h2>Migrate at Your Own Pace</h2>
-            <p>Honua runs alongside your existing servers. Phase in cloud native workflows without breaking current apps.</p>
+        <section class="section section-contrast">
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">Proof</p>
+              <h2>Compatibility and conformance need dedicated room.</h2>
+              <p>
+                Honua already carries launch-facing compatibility and conformance evidence across OGC API, WMS, WMTS,
+                GeoServices-style surfaces, and SDK compatibility guidance. The site should expose that proof, not bury it.
+              </p>
+              <a class="text-link" href="protocols.html">Explore protocol coverage</a>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">Licensing</p>
+              <h2>Licensing should be explicit, not implied.</h2>
+              <p>
+                The server follows an open-core ELv2 model while the official SDKs and mobile/tooling repos use Apache 2.0.
+                That distinction matters for trust, procurement, and migration conversations.
+              </p>
+              <a class="text-link" href="pricing.html">Read pricing and licensing</a>
+            </article>
           </div>
-          <div class="grid two">
-            <div class="card">
-              <h3>Low-risk transition</h3>
-              <ul class="bullet-list">
-                <li>Import existing Esri REST services directly</li>
-                <li>Preserve service structures and metadata</li>
-                <li>Existing ArcGIS clients keep working &mdash; same endpoints, same protocols</li>
-                <li>Run alongside legacy systems during transition</li>
-                <li>No "rip-and-replace" required</li>
-              </ul>
-            </div>
-            <div class="card">
-              <h3>Data ingestion</h3>
-              <p>Import and publish from common GIS formats.</p>
-              <div class="pill-list">
-                <span class="pill">Esri REST services</span>
-                <span class="pill">GeoJSON</span>
-                <span class="pill">Shapefile (zip)</span>
-                <span class="pill">GeoPackage</span>
-                <span class="pill">GPX</span>
-                <span class="pill">KML</span>
-                <span class="pill">WKT</span>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Choose a Path</p>
+            <h2>Start from the surface that matches your team.</h2>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card card-link">
+              <h3>Platform</h3>
+              <p>See the full runtime, control plane direction, deployment targets, and migration posture.</p>
+              <a class="text-link" href="platform.html">Go to Platform</a>
+            </article>
+            <article class="card card-link">
+              <h3>Protocols</h3>
+              <p>Understand where GeoServices REST, OGC API, OData, gRPC, MCP, and tiles fit together.</p>
+              <a class="text-link" href="protocols.html">Go to Protocols</a>
+            </article>
+            <article class="card card-link">
+              <h3>SDKs</h3>
+              <p>Pick a client surface for JavaScript, .NET, Python, migration tooling, or agent workflows.</p>
+              <a class="text-link" href="sdks.html">Go to SDKs</a>
+            </article>
+            <article class="card card-link">
+              <h3>Mobile</h3>
+              <p>See the MAUI-first field collection and offline sync story without per-user licensing.</p>
+              <a class="text-link" href="mobile.html">Go to Mobile</a>
+            </article>
+            <article class="card card-link">
+              <h3>Pricing</h3>
+              <p>Review edition boundaries, license posture, and why Honua does not charge by user seat, protocol, or client library.</p>
+              <a class="text-link" href="pricing.html">Go to Pricing</a>
+            </article>
+            <article class="card card-link">
+              <h3>Docs</h3>
+              <p>Start with a quickstart, first API call, SDK install path, and direct links into the deeper docs.</p>
+              <a class="text-link" href="docs.html">Go to Docs</a>
+            </article>
+          </div>
+        </section>
+
+        <section id="contact" class="section contact-section">
+          <div class="contact-grid">
+            <div class="contact-copy">
+              <p class="eyebrow">Early Access</p>
+              <h2>Planning a migration, launch, or field workflow rollout?</h2>
+              <p>
+                Tell us what you are replacing, what client surfaces matter, and whether the pressure is standards,
+                licensing, mobile, SDK adoption, or platform consolidation.
+              </p>
+              <div class="contact-points">
+                <span>GeoServer and ArcGIS replacement</span>
+                <span>SDK and quickstart support</span>
+                <span>Mobile and field workflow planning</span>
+                <span>Licensing and procurement questions</span>
               </div>
-              <p class="note" style="margin-top: 12px">All data lives in PostGIS. No proprietary formats, no geodatabase lock-in.</p>
             </div>
-          </div>
-        </section>
-
-        <section id="cloudnative" class="section reveal delay-4">
-          <div class="section-header">
-            <h2>Cloud-Native Operations Without Tradeoffs</h2>
-            <p>Built for production geospatial workloads with elasticity, observability, and operational simplicity from day one.</p>
-          </div>
-          <div class="grid three">
-            <div class="card highlight-card">
-              <h3>Elastic runtime</h3>
-              <ul class="bullet-list">
-                <li>Run on Kubernetes, ECS/Fargate, Container Apps, Lambda, or Azure Functions</li>
-                <li>Scale out for demand spikes and scale to zero for bursty workloads</li>
-                <li>Sub-second cold starts with AOT compilation</li>
-              </ul>
-              <p class="note">Choose deployment topology by latency, traffic profile, and operational constraints.</p>
-            </div>
-            <div class="card highlight-card">
-              <h3>Minimal operational footprint</h3>
-              <ul class="bullet-list">
-                <li><strong>PostGIS</strong> &mdash; only required dependency</li>
-                <li><strong>Redis</strong> &mdash; optional, for multi-node caching</li>
-                <li>No GDAL, no Java runtime, no Windows Server</li>
-                <li>Single container, ~167 MB AOT image</li>
-              </ul>
-              <p class="note">Fewer moving parts means faster upgrades, simpler incident response, and lower operational overhead.</p>
-            </div>
-            <div class="card highlight-card">
-              <h3>Production-ready observability</h3>
-              <ul class="bullet-list">
-                <li>Stateless, horizontal auto-scaling</li>
-                <li>OpenTelemetry traces and metrics built in</li>
-                <li>Health probes for orchestrator-driven restarts</li>
-                <li>Infrastructure as Code (Terraform, Helm)</li>
-              </ul>
-              <div class="pill-list" style="margin-top: 8px">
-                <span class="pill">Kubernetes</span>
-                <span class="pill">ECS/Fargate</span>
-                <span class="pill">Container Apps</span>
-                <span class="pill">Lambda</span>
-                <span class="pill">Azure Functions</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section id="open-core" class="section reveal delay-5">
-          <div class="callout">Open source under the Apache License 2.0. Free to use, modify, and redistribute.</div>
-        </section>
-
-        <section id="get-started" class="section reveal delay-5">
-          <div class="section-header">
-            <h2>Deploy in Minutes</h2>
-            <p>Self-serve deployment for evaluation. Docker or Kubernetes.</p>
-          </div>
-          <div class="grid two">
-            <div class="card">
-              <h3>Docker</h3>
-              <pre><code>docker run -p 8080:8080 \
-  -e ConnectionStrings__DefaultConnection="Host=postgres;Database=honua;Username=postgres;Password=postgres" \
-  -e HONUA_ADMIN_PASSWORD="change-me" \
-  honuaio/honua-server:latest</code></pre>
-            </div>
-            <div class="card">
-              <h3>Kubernetes (Helm)</h3>
-              <pre><code>git clone https://github.com/honua-io/honua-helm.git
-helm dependency update honua-helm/honua
-helm install honua honua-helm/honua \
-  --set secret.env.ConnectionStrings__DefaultConnection="Host=postgres;Database=honua;Username=honua;Password=honua" \
-  --set secret.env.HONUA_ADMIN_PASSWORD="change-me"</code></pre>
-            </div>
-          </div>
-        </section>
-
-        <section id="contact" class="section footer-cta reveal delay-6">
-          <div class="section-header">
-            <h2>Ready to Evaluate?</h2>
-            <p>We're looking for early partners &mdash; organizations evaluating alternatives to ArcGIS Server, modernizing GIS infrastructure, or adopting open standards. Tell us about your use case.</p>
-          </div>
-          <form class="contact-form" action="https://formsubmit.co/mike@honua.io" method="POST">
-            <input type="hidden" name="_subject" value="Honua Early Access Request" />
-            <input type="hidden" name="_captcha" value="true" />
-            <input type="hidden" name="_template" value="table" />
-            <label>
-              Organization
-              <input type="text" name="organization" required />
-            </label>
-            <label>
-              Work email
-              <input type="email" name="email" required />
-            </label>
-            <label class="full-width">
-              Current stack and use case
-              <textarea name="use_case" rows="4" required></textarea>
-            </label>
-            <button class="btn primary" type="submit">Submit Request</button>
-            <a class="btn ghost" href="mailto:mike@honua.io?subject=Honua%20Early%20Access">Use Email Instead</a>
-          </form>
-          <div class="cta-row">
-            <a
-              class="btn primary"
-              href="#contact"
-              >Request Early Access Form</a
-            >
-            <a
-              class="btn secondary"
-              href="https://honua.gitbook.io/honuaio/devops-guide/infrastructure"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Self-Serve Setup</a
-            >
-            <a
-              class="btn ghost"
-              href="https://github.com/honua-io/honua-server"
-              target="_blank"
-              rel="noopener noreferrer"
-              >GitHub</a
-            >
+            <form class="contact-form" action="https://formsubmit.co/mike@honua.io" method="POST">
+              <input type="hidden" name="_captcha" value="true" />
+              <input type="hidden" name="_subject" value="Honua.io inquiry" />
+              <label>
+                Name
+                <input type="text" name="name" autocomplete="name" required />
+              </label>
+              <label>
+                Work Email
+                <input type="email" name="email" autocomplete="email" required />
+              </label>
+              <label>
+                Company
+                <input type="text" name="company" autocomplete="organization" />
+              </label>
+              <label>
+                What are you trying to ship?
+                <textarea
+                  name="message"
+                  rows="6"
+                  placeholder="Examples: GeoServer migration, ArcGIS cost pressure, mobile field workflow, MCP access for agents, SDK rollout, launch docs."
+                  required
+                ></textarea>
+              </label>
+              <button class="button button-primary" type="submit">Request Early Access</button>
+            </form>
           </div>
         </section>
       </main>
 
       <footer class="footer">
-        <div>
-          <strong>Honua</strong>
-          <p>Cloud-native geospatial APIs with open standards and no lock-in.</p>
-          <p class="note">&copy; 2026 Honua. Licensed under Apache License 2.0.</p>
-        </div>
-        <div>
-          <p>Contact &amp; feedback</p>
-          <a href="mailto:mike@honua.io">mike@honua.io</a>
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">
+              Cloud-native geospatial infrastructure for APIs, SDKs, mobile, and AI workflows.
+            </p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="pricing.html">Pricing and Licensing</a>
+            <a href="docs.html">Docs and Quickstart</a>
+            <a href="https://github.com/honua-io/honua-server" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
         </div>
       </footer>
     </div>

--- a/mobile.html
+++ b/mobile.html
@@ -1,0 +1,159 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua Mobile | MAUI, Offline GeoPackage Sync, gRPC Field Workflows</title>
+    <meta
+      name="description"
+      content="Honua Mobile brings MAUI-first field workflows, GeoPackage offline storage, forms, background sync, and gRPC-first access into the platform story."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Mobile</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="platform.html">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a class="active" href="mobile.html" aria-current="page">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Mobile</p>
+          <h1>Field workflows should be visible at the top level.</h1>
+          <p class="page-intro">
+            Mobile is no longer an afterthought. The April platform story includes MAUI-first field collection,
+            offline GeoPackage sync, forms, background upload, and gRPC-first performance for operational teams.
+          </p>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Mobile Positioning</p>
+            <h2>What the site needs to say clearly.</h2>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card">
+              <p class="card-kicker">Offline</p>
+              <h3>GeoPackage-backed storage</h3>
+              <p>Offline maps, queued edits, sync cursors, and field data all live in a standards-friendly GeoPackage workflow.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Transport</p>
+              <h3>gRPC-first when it matters</h3>
+              <p>Unary and streaming access patterns support large feature retrieval and collaboration flows with lower overhead than pure REST polling.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Framework</p>
+              <h3>MAUI-first cross-platform</h3>
+              <p>The current mobile lane is rooted in .NET MAUI with iOS, Android, and Windows support, which makes it legible to enterprise app teams.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Field UX</p>
+              <h3>Forms and record workflows</h3>
+              <p>Dynamic form schema, validation, calculated fields, duplicate detection, and record lifecycle support define the field workflow story.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Sync</p>
+              <h3>Background upload and conflict handling</h3>
+              <p>Connectivity-aware background sync and conflict strategies turn mobile from a demo into an operational lane.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Economics</p>
+              <h3>No per-user mobile tax</h3>
+              <p>The site should say directly that the mobile story is not priced like a per-seat field app subscription stack.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Mobile Stack</p>
+            <h2>What is part of the current mobile surface.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Package / layer</th>
+                  <th>Purpose</th>
+                  <th>Public message</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Honua.Mobile.Sdk</td>
+                  <td>Transport, auth, and mobile client surface</td>
+                  <td>Use Honua APIs from MAUI apps without standing up a separate mobile backend product.</td>
+                </tr>
+                <tr>
+                  <td>Honua.Mobile.Field</td>
+                  <td>Forms, validation, record workflows</td>
+                  <td>Field collection is part of the platform, not a disconnected add-on.</td>
+                </tr>
+                <tr>
+                  <td>Honua.Mobile.Offline</td>
+                  <td>GeoPackage storage and sync engine</td>
+                  <td>Offline-first behavior should be a headline feature, not buried implementation detail.</td>
+                </tr>
+                <tr>
+                  <td>Honua.Mobile.Maui</td>
+                  <td>MAUI service registration and UI integration</td>
+                  <td>Show that mobile development is part of the same developer story as the server and SDKs.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">Positioning</p>
+              <h2>Mobile changes the category.</h2>
+              <p>
+                Once mobile is real, Honua stops reading as only a server replacement and starts reading as a platform for collection, sync, data access, and delivery.
+              </p>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">Pricing</p>
+              <h2>Licensing becomes part of the field story.</h2>
+              <p>
+                Field buyers are sensitive to per-user mobile pricing. The site should connect mobile capabilities to the broader no-per-user posture.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>Mobile only works if the pricing and docs story are equally clear.</h2>
+          <p>
+            After a visitor understands the mobile lane, the next questions are almost always licensing, procurement, and how fast they can try it.
+          </p>
+          <div class="action-row">
+            <a class="button button-primary" href="pricing.html">View Pricing</a>
+            <a class="button button-secondary" href="docs.html">Open Docs</a>
+            <a class="button button-ghost" href="sdks.html">Back to SDKs</a>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/platform.html
+++ b/platform.html
@@ -1,0 +1,210 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua Platform | Runtime, Control Plane, SDKs, and Deployment</title>
+    <meta
+      name="description"
+      content="See the Honua platform shape: multi-protocol server runtime, admin and control plane direction, SDKs, mobile, MCP, migration posture, and cloud-native deployment targets."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Platform Overview</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a class="active" href="platform.html" aria-current="page">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Platform</p>
+          <h1>The April 1 story is a platform, not a landing page.</h1>
+          <p class="page-intro">
+            Honua combines a multi-protocol server runtime, typed SDKs, mobile field foundations, MCP tooling,
+            migration helpers, and cloud-native deployment options. The public site should present those as one coherent system.
+          </p>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Differentiation</p>
+            <h2>Compatibility gets attention. gRPC and MCP create the forward edge.</h2>
+            <p class="section-copy">
+              The site should make one strategic distinction very clear: GeoServices REST and OGC compatibility win trust during migration, while `gRPC` and `MCP` are the modern rails that make Honua feel like a next-generation platform.
+            </p>
+          </div>
+          <div class="detail-grid">
+            <article class="detail-card detail-card-accent">
+              <p class="eyebrow">gRPC</p>
+              <h2>Fast path for apps, SDKs, and mobile</h2>
+              <p>
+                `gRPC` is the typed binary rail for application builders and field workflows. It should read as part of the product’s technical edge, not as a buried implementation detail.
+              </p>
+            </article>
+            <article class="detail-card detail-card-spot">
+              <p class="eyebrow">MCP</p>
+              <h2>Agent path into the platform</h2>
+              <p>
+                `MCP` is what makes Honua legible to AI assistants and coding agents. That matters enough to be visible at the platform layer, not only in a niche docs page.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Core Layers</p>
+            <h2>What the platform needs to say clearly.</h2>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card">
+              <p class="card-kicker">Runtime</p>
+              <h3>Server core</h3>
+              <p>
+                The runtime serves GeoServices REST, OGC API, OData, tiles, WMS, WMTS, unary gRPC, and MCP-adjacent discovery/query access from one PostGIS-backed system.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Admin</p>
+              <h3>Control plane direction</h3>
+              <p>
+                Admin APIs and the admin UI are the foundation for publishing, governance, deployment coordination, and future control-plane workflows.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Integrations</p>
+              <h3>SDKs and agents</h3>
+              <p>
+                JavaScript, .NET, Python, migration utilities, and the MCP server keep evaluation friction low and make the platform legible to developers.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Mobile</p>
+              <h3>Field workflows</h3>
+              <p>
+                The MAUI-first mobile track adds offline GeoPackage sync, form workflows, background upload, and gRPC-first access for field operations.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Migration</p>
+              <h3>Replacement wedge</h3>
+              <p>
+                ArcGIS and GeoServer displacement remain the sharpest story: compatibility, staged migration, standards, and pricing clarity.
+              </p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Operations</p>
+              <h3>Deploy where the team already runs</h3>
+              <p>
+                Docker, Kubernetes, AWS, Azure, serverless, and infrastructure-as-code should stay visible because deployment freedom is part of the product.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Surface Map</p>
+            <h2>The public story should connect repos into one product.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Surface</th>
+                  <th>Role in the platform</th>
+                  <th>What the site should emphasize</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Honua Server</td>
+                  <td>Protocol runtime, admin API, deployment target, migration destination</td>
+                  <td>Compatibility, conformance, standards, operational footprint, and licensing model</td>
+                </tr>
+                <tr>
+                  <td>Admin and Control Plane</td>
+                  <td>Publishing, governance, environment management, rollout direction</td>
+                  <td>Operational confidence and future control-plane credibility</td>
+                </tr>
+                <tr>
+                  <td>SDKs</td>
+                  <td>Developer adoption surface across JavaScript, .NET, and Python</td>
+                  <td>Typed clients, quickstarts, migration tooling, and compatibility contracts</td>
+                </tr>
+                <tr>
+                  <td>Mobile</td>
+                  <td>Field collection and offline workflows</td>
+                  <td>GeoPackage sync, forms, MAUI, background sync, and gRPC-first performance</td>
+                </tr>
+                <tr>
+                  <td>MCP</td>
+                  <td>Agent and AI integration surface</td>
+                  <td>Discovery, schema inspection, filtered query workflows, and secure tool surfaces</td>
+                </tr>
+                <tr>
+                  <td>Private operator layer</td>
+                  <td>Enterprise or partner-led AI DevOps/copilot tooling</td>
+                  <td>Keep it clearly separate from the open-core runtime: rollout planning, delegated ops, and implementation workflows can be private without undermining the public platform.</td>
+                </tr>
+                <tr>
+                  <td>Pricing and Editions</td>
+                  <td>Trust and procurement narrative</td>
+                  <td>No per-user fees, no protocol gating, open-core boundary, and clear edition differences</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="note-grid">
+            <article class="note-card">
+              <h3>What the old site underplays</h3>
+              <p>
+                MCP, mobile, gRPC, SDK breadth, licensing nuance, and the control-plane arc were all either absent or too buried to carry the actual product story.
+              </p>
+            </article>
+            <article class="note-card">
+              <h3>What this redesign changes</h3>
+              <p>
+                The site becomes a map of the platform: protocol surface, developer surface, mobile surface, procurement surface, migration surface, and a clearly separated private operator layer.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>Drill into the exact surfaces your team needs.</h2>
+          <p>
+            Protocols explain interoperability. SDKs explain adoption. Mobile explains field workflows. Pricing explains whether the platform is actually practical to buy and deploy.
+          </p>
+          <div class="action-row">
+            <a class="button button-primary" href="protocols.html">View Protocols</a>
+            <a class="button button-secondary" href="sdks.html">View SDKs</a>
+            <a class="button button-ghost" href="pricing.html">View Pricing</a>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,264 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua Pricing and Licensing | No Per-User Fees, Clear Edition Boundaries</title>
+    <meta
+      name="description"
+      content="Understand Honua pricing and licensing: no per-user fees, no protocol gating, ELv2 for the server runtime, Apache 2.0 for official SDKs and tooling, and clear edition boundaries."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Pricing and Licensing</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="platform.html">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a class="active" href="pricing.html" aria-current="page">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Pricing and Licensing</p>
+          <h1>No seat tax. No protocol tax. No SDK tax.</h1>
+          <p class="page-intro">
+            The site needs a plain-language pricing page because buyers will not infer the right story from a single tagline.
+            Honua uses an open-core model with clear runtime boundaries: no per-user fees, no protocol gating, no add-on SDK licensing, and no credit-style meter. Commercial tiers start when a team needs coordinated scale, streaming depth, governance, and enterprise support.
+          </p>
+          <div class="callout">
+            You should not pay more because you added more users, more client apps, more standards, more field devices, or more agent workflows.
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">What Buyers Should Understand Fast</p>
+            <h2>The model should be legible in one scan.</h2>
+          </div>
+          <div class="mini-grid">
+            <article class="note-card">
+              <h3>No per-user fees</h3>
+              <p>Adding analysts, viewers, operators, or field staff does not trigger a new seat purchase.</p>
+            </article>
+            <article class="note-card">
+              <h3>No protocol tax</h3>
+              <p>GeoServices REST, OGC API, OData, tiles, and SDK access are part of adoption, not hidden add-ons.</p>
+            </article>
+            <article class="note-card">
+              <h3>No SDK surcharge</h3>
+              <p>JavaScript, .NET, Python, mobile tooling, and MCP belong in the platform story without extra client-side licensing friction.</p>
+            </article>
+            <article class="note-card">
+              <h3>Pay for production depth</h3>
+              <p>Commercial tiers are about distributed coordination, streaming, governance, support, and enterprise controls.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">What We Refuse To Monetize</p>
+            <h2>The posture should be explicit.</h2>
+          </div>
+          <div class="mini-grid">
+            <article class="note-card">
+              <h3>Users and operators</h3>
+              <p>Scale your user base without buying new seats every time a viewer, analyst, or field user appears.</p>
+            </article>
+            <article class="note-card">
+              <h3>Protocols</h3>
+              <p>GeoServices REST, OGC API, OData, tiles, and SDK access should stay visible because they are part of adoption, not premium upsell bait.</p>
+            </article>
+            <article class="note-card">
+              <h3>SDKs and client surfaces</h3>
+              <p>The product story stays cleaner when developer surfaces, mobile tooling, and client access are not split into optional taxes.</p>
+            </article>
+            <article class="note-card">
+              <h3>What commercial tiers actually cover</h3>
+              <p>Higher editions should map to distributed coordination, streaming depth, governance, support, and enterprise controls.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Private Operator Layer</p>
+            <h2>One surface is intentionally not open-core.</h2>
+          </div>
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">Public</p>
+              <h2>Runtime, protocols, SDKs, mobile, and base MCP</h2>
+              <p>
+                The open-core promise covers the server runtime, protocol surfaces, official SDKs, mobile tooling, and the base MCP data-access layer.
+              </p>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">Private</p>
+              <h2>AI DevOps/operator copilot</h2>
+              <p>
+                Operator-grade rollout planning, delegated operations, and implementation-partner workflows can remain private enterprise tooling on top of the public control-plane API.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">What You Never Pay For</p>
+              <h2>User count, protocol usage, or client access.</h2>
+              <p>
+                Honua should not feel like a platform where every new viewer, field operator, protocol, or SDK becomes a separate purchasing event. That is exactly the pricing shape many teams are trying to leave behind.
+              </p>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">What You Do Pay For</p>
+              <h2>Coordinated scale, governance, and enterprise confidence.</h2>
+              <p>
+                The paid story is stronger when it is framed around distributed cache, streaming depth, support, governance, compliance, and change management instead of artificial product crippling.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Edition Model</p>
+            <h2>Community, Pro, and Enterprise have different jobs.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>Community</th>
+                  <th>Pro</th>
+                  <th>Enterprise</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Price posture</td>
+                  <td>Free self-hosted under ELv2</td>
+                  <td>Per-node commercial license</td>
+                  <td>Per-node annual contract</td>
+                </tr>
+                <tr>
+                  <td>Protocols and SDK access</td>
+                  <td>Core protocol and SDK surface stays visible</td>
+                  <td>Same protocol family with stronger runtime depth</td>
+                  <td>Same protocol family with governance and compliance controls</td>
+                </tr>
+                <tr>
+                  <td>Primary boundary</td>
+                  <td>Single-process deployment with in-memory coordination</td>
+                  <td>Distributed cache, streaming, advanced runtime capabilities</td>
+                  <td>SSO, RBAC, audit, change management, multi-tenancy, premium support</td>
+                </tr>
+                <tr>
+                  <td>Best fit</td>
+                  <td>Single-team replacement, evaluation, community deployment</td>
+                  <td>Production workloads that need throughput and coordinated scale</td>
+                  <td>Organizations with governance, compliance, and multi-team requirements</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">License Split</p>
+            <h2>Different repos have different license jobs.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Component</th>
+                  <th>License</th>
+                  <th>Why it matters publicly</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Honua Server runtime</td>
+                  <td>Elastic License 2.0</td>
+                  <td>Use, self-host, modify, and deploy it; do not resell it as a managed third-party hosted service.</td>
+                </tr>
+                <tr>
+                  <td>Official SDKs</td>
+                  <td>Apache 2.0</td>
+                  <td>Developers can adopt the clients without ambiguity or closed-client friction.</td>
+                </tr>
+                <tr>
+                  <td>Mobile tooling and examples</td>
+                  <td>Apache 2.0</td>
+                  <td>Field teams and integrators can evaluate the mobile surface without separate client-side licensing questions.</td>
+                </tr>
+                <tr>
+                  <td>Site and collateral</td>
+                  <td>Apache 2.0</td>
+                  <td>The public trust layer should be transparent and easy to reuse internally.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            The pricing page should answer procurement questions directly: no per-user fees, no credit system, no protocol gating, and clear explanation of what ELv2 means in practice.
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">Economics</p>
+              <h2>What buyers actually compare.</h2>
+              <p>
+                Most migration buyers are comparing against per-user ArcGIS cost growth, extension taxes, and operational drag.
+                The site should speak that language directly.
+              </p>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">Trust</p>
+              <h2>Licensing is part of trust, not fine print.</h2>
+              <p>
+                If the public story is unclear about license boundaries, procurement and legal will assume the worst. This page should remove that ambiguity.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Try It</p>
+          <h2>Pricing works best when paired with a fast quickstart.</h2>
+          <p>
+            After a buyer understands the edition model, the next question is whether a team can install one SDK and get to a successful request quickly.
+          </p>
+          <div class="action-row">
+            <a class="button button-primary" href="docs.html">Open Docs</a>
+            <a class="button button-secondary" href="sdks.html">View SDKs</a>
+            <a class="button button-ghost" href="index.html#contact">Talk to Us</a>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/protocols.html
+++ b/protocols.html
@@ -1,0 +1,299 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua Protocols | GeoServices REST, OGC API, OData, gRPC, MCP</title>
+    <meta
+      name="description"
+      content="Understand the Honua protocol surface: GeoServices REST, OGC API, OData v4, gRPC, MCP, vector tiles, WMS, and WMTS."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Protocols</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="platform.html">Platform</a>
+          <a class="active" href="protocols.html" aria-current="page">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Protocols</p>
+          <h1>Compatibility gets teams in. gRPC and MCP show what is actually new.</h1>
+          <p class="page-intro">
+            Honua should be legible as the place where GeoServices REST, OGC API, OData, gRPC, MCP, and cloud-native tiles meet.
+            But the protocol page should not treat every surface as equally strategic. Compatibility explains migration. `gRPC` and `MCP` explain why the platform is modern.
+          </p>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Innovation Layer</p>
+            <h2>The real protocol differentiation is here.</h2>
+          </div>
+          <div class="detail-grid">
+            <article class="detail-card detail-card-accent">
+              <p class="eyebrow">gRPC</p>
+              <h2>Application and mobile performance rail</h2>
+              <p>
+                `gRPC` is not just another protocol checkbox. It is the binary transport that makes app integrations, MAUI field workflows, and high-throughput client paths feel substantially different from pure REST-era GIS stacks.
+              </p>
+              <ul class="bullet-list">
+                <li>Strong fit for typed SDKs and mobile field clients.</li>
+                <li>Unary support belongs in the open protocol story.</li>
+                <li>Streaming is the commercial scale path, not the compatibility wedge.</li>
+              </ul>
+            </article>
+            <article class="detail-card detail-card-spot">
+              <p class="eyebrow">MCP</p>
+              <h2>Agent-native geospatial access rail</h2>
+              <p>
+                `MCP` is the surface that makes Honua legible to coding agents, copilots, and analyst assistants. It turns service discovery, schema inspection, and filtered queries into tool-safe workflows instead of ad hoc scraping.
+              </p>
+              <ul class="bullet-list">
+                <li>Discovery and query workflows for AI assistants.</li>
+                <li>Direct bridge from geospatial systems into agent ecosystems.</li>
+                <li>A meaningful differentiation point versus legacy GIS stacks.</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Protocol Diagram</p>
+            <h2>How the protocol layers actually fit together.</h2>
+            <p class="section-copy">
+              The site needs a visual that separates migration compatibility from forward-looking integration rails. This makes it easier to see why `gRPC` and `MCP` matter without discarding the compatibility story.
+            </p>
+          </div>
+          <div class="diagram-shell">
+            <svg class="platform-diagram" viewBox="0 0 1140 620" role="img" aria-label="Protocol diagram showing clients entering through compatibility, gRPC, and MCP rails into the Honua runtime">
+              <defs>
+                <linearGradient id="protoInk" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stop-color="#14252c" />
+                  <stop offset="100%" stop-color="#203b44" />
+                </linearGradient>
+                <marker id="protoArrowInk" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M0 0L10 5L0 10z" fill="#37525d" />
+                </marker>
+                <marker id="protoArrowAccent" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M0 0L10 5L0 10z" fill="#157c68" />
+                </marker>
+                <marker id="protoArrowSpot" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+                  <path d="M0 0L10 5L0 10z" fill="#eb6f2f" />
+                </marker>
+              </defs>
+
+              <rect x="0" y="0" width="1140" height="620" rx="30" fill="#fffaf3" />
+              <text x="74" y="76" class="diagram-title">Client classes</text>
+              <rect x="60" y="112" width="226" height="84" rx="20" class="diagram-node diagram-node-light" />
+              <text x="86" y="146" class="diagram-node-title">Existing GIS clients</text>
+              <text x="86" y="174" class="diagram-node-copy">ArcGIS, QGIS, web map clients</text>
+
+              <rect x="60" y="224" width="226" height="84" rx="20" class="diagram-node diagram-node-light" />
+              <text x="86" y="258" class="diagram-node-title">Business and data tools</text>
+              <text x="86" y="286" class="diagram-node-copy">BI, analytics, enterprise data apps</text>
+
+              <rect x="60" y="336" width="226" height="84" rx="20" class="diagram-node diagram-node-highlight" />
+              <text x="86" y="370" class="diagram-node-title">SDK apps and mobile</text>
+              <text x="86" y="398" class="diagram-node-copy">Typed clients, services, MAUI field apps</text>
+
+              <rect x="60" y="448" width="226" height="84" rx="20" class="diagram-node diagram-node-spot" />
+              <text x="86" y="482" class="diagram-node-title">Agents and copilots</text>
+              <text x="86" y="510" class="diagram-node-copy">Discovery, schema, query workflows</text>
+
+              <text x="348" y="76" class="diagram-title">Protocol rails</text>
+              <rect x="330" y="112" width="244" height="120" rx="22" class="diagram-panel diagram-panel-neutral" />
+              <text x="360" y="148" class="diagram-panel-title">Compatibility rail</text>
+              <text x="360" y="178" class="diagram-panel-copy">GeoServices REST, OGC API, OData, tiles</text>
+              <text x="360" y="203" class="diagram-panel-copy">Migration continuity and open standards</text>
+
+              <rect x="330" y="256" width="244" height="120" rx="22" class="diagram-panel diagram-panel-accent" />
+              <text x="360" y="292" class="diagram-panel-title">gRPC rail</text>
+              <text x="360" y="322" class="diagram-panel-copy">High-throughput binary path for SDKs and mobile</text>
+              <text x="360" y="347" class="diagram-panel-copy">Unary open, streaming scale path</text>
+
+              <rect x="330" y="400" width="244" height="120" rx="22" class="diagram-panel diagram-panel-spot" />
+              <text x="360" y="436" class="diagram-panel-title">MCP rail</text>
+              <text x="360" y="466" class="diagram-panel-copy">Agent-safe discovery, schema, and query access</text>
+              <text x="360" y="491" class="diagram-panel-copy">Modern AI integration path</text>
+
+              <text x="650" y="76" class="diagram-title">Honua runtime</text>
+              <rect x="628" y="112" width="298" height="408" rx="28" fill="url(#protoInk)" />
+              <text x="662" y="152" class="diagram-platform-title">Unified geospatial platform</text>
+              <text x="662" y="190" class="diagram-platform-copy">Server runtime</text>
+              <text x="662" y="218" class="diagram-platform-copy">Admin API and admin UI</text>
+              <text x="662" y="246" class="diagram-platform-copy">SDKs and migration tooling</text>
+              <text x="662" y="274" class="diagram-platform-copy">Mobile sync and field workflows</text>
+              <text x="662" y="302" class="diagram-platform-copy">MCP package and agent access</text>
+              <rect x="660" y="338" width="234" height="56" rx="16" class="diagram-chip diagram-chip-accent" />
+              <text x="682" y="372" class="diagram-chip-title">gRPC = app and mobile acceleration</text>
+              <rect x="660" y="410" width="234" height="56" rx="16" class="diagram-chip diagram-chip-spot" />
+              <text x="682" y="444" class="diagram-chip-title">MCP = AI and agent integration</text>
+
+              <text x="970" y="76" class="diagram-title">Outcomes</text>
+              <rect x="946" y="140" width="150" height="84" rx="20" class="diagram-node diagram-node-light" />
+              <text x="970" y="174" class="diagram-node-title">Migration</text>
+              <text x="970" y="202" class="diagram-node-copy">Low-risk replacement path</text>
+
+              <rect x="946" y="266" width="150" height="84" rx="20" class="diagram-node diagram-node-highlight" />
+              <text x="970" y="300" class="diagram-node-title">Apps + mobile</text>
+              <text x="970" y="328" class="diagram-node-copy">Faster, typed, operational clients</text>
+
+              <rect x="946" y="392" width="150" height="84" rx="20" class="diagram-node diagram-node-spot" />
+              <text x="970" y="426" class="diagram-node-title">Agents</text>
+              <text x="970" y="454" class="diagram-node-copy">Tool-safe AI access</text>
+
+              <line x1="286" y1="154" x2="330" y2="154" class="diagram-line" marker-end="url(#protoArrowInk)" />
+              <line x1="286" y1="266" x2="330" y2="190" class="diagram-line" marker-end="url(#protoArrowInk)" />
+              <line x1="286" y1="378" x2="330" y2="316" class="diagram-line-accent" marker-end="url(#protoArrowAccent)" />
+              <line x1="286" y1="490" x2="330" y2="460" class="diagram-line-spot" marker-end="url(#protoArrowSpot)" />
+
+              <line x1="574" y1="172" x2="628" y2="206" class="diagram-line" marker-end="url(#protoArrowInk)" />
+              <line x1="574" y1="316" x2="628" y2="316" class="diagram-line-accent" marker-end="url(#protoArrowAccent)" />
+              <line x1="574" y1="460" x2="628" y2="438" class="diagram-line-spot" marker-end="url(#protoArrowSpot)" />
+
+              <line x1="926" y1="206" x2="946" y2="182" class="diagram-line" marker-end="url(#protoArrowInk)" />
+              <line x1="926" y1="316" x2="946" y2="308" class="diagram-line-accent" marker-end="url(#protoArrowAccent)" />
+              <line x1="926" y1="438" x2="946" y2="434" class="diagram-line-spot" marker-end="url(#protoArrowSpot)" />
+            </svg>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Coverage</p>
+            <h2>The headline protocol set.</h2>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card">
+              <p class="card-kicker">GeoServices REST</p>
+              <h3>ArcGIS-compatible runtime</h3>
+              <p>FeatureServer, MapServer, ImageServer, and Geometry Service patterns for low-risk migration and client continuity.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">OGC API</p>
+              <h3>Standards-first delivery</h3>
+              <p>OGC API Features, Tiles, and Maps stay central for open standards buyers, QGIS workflows, and conformance-backed proof.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">OData v4</p>
+              <h3>Spatial data in business systems</h3>
+              <p>Excel, Power BI, Tableau, ERP, and low-code systems become part of the platform story instead of side integrations.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">gRPC</p>
+              <h3>Binary transport for high-throughput paths</h3>
+              <p>`gRPC` is the modern app and mobile rail. Unary support is part of the open surface. Streaming is the scale and performance unlock that differentiates paid runtime tiers.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">MCP</p>
+              <h3>Agent-native access</h3>
+              <p>`MCP` gives AI assistants and agents a safe path to discovery, schema inspection, and query workflows on top of Honua data, and it should read as a platform innovation rather than a footnote.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Tiles and Classic OGC</p>
+              <h3>MVT, WMS, and WMTS</h3>
+              <p>Vector tiles, WMS 1.3, and WMTS 1.0 keep the platform useful across mapping stacks, older integrations, and standards-heavy environments.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Edition Boundary</p>
+            <h2>Do not gate protocols. Gate runtime capability.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Surface</th>
+                  <th>Community</th>
+                  <th>Pro / Enterprise expansion</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>GeoServices REST, OGC API, OData, tiles, WMS, WMTS</td>
+                  <td>Available in the base server surface</td>
+                  <td>Same protocol family, with stronger scale and governance around it</td>
+                </tr>
+                <tr>
+                  <td>gRPC</td>
+                  <td>Unary gRPC support is part of the open protocol surface</td>
+                  <td>Streaming unlocks the high-throughput binary path for larger workloads</td>
+                </tr>
+                <tr>
+                  <td>MCP</td>
+                  <td>REST-backed MCP server for discovery and query workflows</td>
+                  <td>Lower-latency transport and richer agent capabilities expand in higher editions</td>
+                </tr>
+                <tr>
+                  <td>SDK access</td>
+                  <td>JavaScript, .NET, Python, and mobile remain visible and accessible</td>
+                  <td>Paid tiers should deepen scale, operations, and governance instead of hiding the SDKs</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            The public pricing story should reinforce the protocol rule: buyers are paying for runtime coordination,
+            streaming depth, governance, and support, not for permission to speak a protocol.
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">Proof</p>
+              <h2>Conformance should be visible.</h2>
+              <p>
+                The launch compatibility contract already carries concrete OGC API, WMS, and WMTS coverage evidence.
+                That proof should live near the protocol story, not disappear into deep docs.
+              </p>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">Migration</p>
+              <h2>Protocol coexistence is what makes migration practical.</h2>
+              <p>
+                Teams can keep ArcGIS-style clients alive while moving toward OGC, OData, `gRPC`, or `MCP`-driven workflows over time. That coexistence is the bridge from compatibility into actual platform differentiation.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Build On Top</p>
+          <h2>Pick the client surface that matches your protocol mix.</h2>
+          <p>
+            The next thing most teams need after protocol clarity is a typed entry point: JavaScript for apps, .NET for enterprise and MAUI, Python for data workflows, and MCP for agent workflows.
+          </p>
+          <div class="action-row">
+            <a class="button button-primary" href="sdks.html">View SDKs</a>
+            <a class="button button-secondary" href="mobile.html">View Mobile</a>
+            <a class="button button-ghost" href="docs.html">Open Docs</a>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -7,7 +7,7 @@ dist_dir="${repo_root}/dist"
 rm -rf "${dist_dir}"
 mkdir -p "${dist_dir}"
 
-cp "${repo_root}/index.html" "${dist_dir}/index.html"
+find "${repo_root}" -maxdepth 1 -name "*.html" -exec cp {} "${dist_dir}" \;
 cp "${repo_root}/styles.css" "${dist_dir}/styles.css"
 cp "${repo_root}/CNAME" "${dist_dir}/CNAME"
 cp "${repo_root}/.nojekyll" "${dist_dir}/.nojekyll"

--- a/scripts/validate-site.sh
+++ b/scripts/validate-site.sh
@@ -3,11 +3,26 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 index_file="${repo_root}/index.html"
+required_pages=(
+  "${repo_root}/platform.html"
+  "${repo_root}/protocols.html"
+  "${repo_root}/sdks.html"
+  "${repo_root}/mobile.html"
+  "${repo_root}/pricing.html"
+  "${repo_root}/docs.html"
+)
 
 if [[ ! -f "${index_file}" ]]; then
   echo "Missing index.html" >&2
   exit 1
 fi
+
+for page in "${required_pages[@]}"; do
+  if [[ ! -f "${page}" ]]; then
+    echo "Missing required page: ${page}" >&2
+    exit 1
+  fi
+done
 
 require_match() {
   local pattern="$1"
@@ -32,10 +47,21 @@ require_match "action=\"https://formsubmit\\.co/mike@honua\\.io\"" "${index_file
 require_match "name=\"_captcha\" value=\"true\"" "${index_file}"
 require_no_match "name=\"_captcha\" value=\"false\"" "${index_file}"
 
-for anchor in capabilities conformance contact; do
-  require_match "href=\"#${anchor}\"" "${index_file}"
-  require_match "id=\"${anchor}\"" "${index_file}"
-done
+require_match "href=\"platform\\.html\"" "${index_file}"
+require_match "href=\"protocols\\.html\"" "${index_file}"
+require_match "href=\"sdks\\.html\"" "${index_file}"
+require_match "href=\"mobile\\.html\"" "${index_file}"
+require_match "href=\"pricing\\.html\"" "${index_file}"
+require_match "href=\"docs\\.html\"" "${index_file}"
+require_match "id=\"contact\"" "${index_file}"
+
+require_match "GeoServices REST" "${repo_root}/protocols.html"
+require_match "MCP" "${repo_root}/protocols.html"
+require_match "JavaScript" "${repo_root}/sdks.html"
+require_match "Python" "${repo_root}/sdks.html"
+require_match "GeoPackage" "${repo_root}/mobile.html"
+require_match "No per-user fees" "${repo_root}/pricing.html"
+require_match "npm install @honua/sdk-js" "${repo_root}/docs.html"
 
 "${repo_root}/scripts/validate-security-headers.sh"
 "${repo_root}/scripts/validate-workflow-pinning.sh"

--- a/sdks.html
+++ b/sdks.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua SDKs | JavaScript, .NET, Python, Migration, MCP</title>
+    <meta
+      name="description"
+      content="Explore the Honua developer surface: JavaScript, .NET, Python, migration tooling, and MCP workflows."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">SDKs</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="platform.html">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a class="active" href="sdks.html" aria-current="page">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">SDKs</p>
+          <h1>The developer story needs first-class pages.</h1>
+          <p class="page-intro">
+            Honua should look like a platform developers can actually build on: typed clients, migration tooling, agent access,
+            compatibility guidance, and direct install paths.
+          </p>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Primary SDKs</p>
+            <h2>Three official SDK lanes, each with a different adoption job.</h2>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card">
+              <p class="card-kicker">JavaScript</p>
+              <h3>Apps, migration, compat layers</h3>
+              <p>The JavaScript SDK covers Honua-first clients, OGC usage, Esri compatibility helpers, migration scanning, and runtime parity matrices.</p>
+              <pre><code>npm install @honua/sdk-js</code></pre>
+            </article>
+            <article class="card">
+              <p class="card-kicker">.NET</p>
+              <h3>Enterprise, admin, and MAUI adjacency</h3>
+              <p>The .NET SDK focuses on gRPC queries, admin workflows, and geocoding, with a natural path into MAUI and broader Microsoft stacks.</p>
+              <pre><code>dotnet add package Honua.Sdk.Grpc --prerelease
+dotnet add package Honua.Sdk.Admin --prerelease</code></pre>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Python</p>
+              <h3>Analysis, automation, and data workflows</h3>
+              <p>The Python SDK gives data teams feature access, geocoding, admin automation, and optional gRPC support for streaming workflows.</p>
+              <pre><code>pip install honua-sdk
+pip install honua-sdk[grpc]</code></pre>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Beyond Basic SDKs</p>
+            <h2>The public developer story is broader than package installs.</h2>
+          </div>
+          <div class="mini-grid">
+            <article class="note-card">
+              <h3>Migration toolkit</h3>
+              <p>
+                The JS lane includes scanners, codemods, compat wrappers, and reconciliation helpers for organizations replacing ArcGIS-centric applications.
+              </p>
+            </article>
+            <article class="note-card">
+              <h3>MCP server package</h3>
+              <p>
+                MCP needs to sit beside the SDK story because agents are now another client class. It is not just a hidden bullet in a docs appendix.
+              </p>
+            </article>
+            <article class="note-card">
+              <h3>Versioning and compatibility</h3>
+              <p>
+                Server and SDK compatibility contracts are part of the product trust layer. The site should surface those expectations instead of assuming developers will infer them.
+              </p>
+            </article>
+            <article class="note-card">
+              <h3>Quickstarts</h3>
+              <p>
+                The docs surface should let a team install one SDK, make one authenticated call, and understand where to go next without hunting across repos.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">How To Choose</p>
+            <h2>Match the SDK to the adoption motion.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>If your team is...</th>
+                  <th>Start here</th>
+                  <th>Why</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Replacing ArcGIS-heavy web apps</td>
+                  <td>JavaScript SDK</td>
+                  <td>Compat wrappers and migration tooling lower the cost of translation.</td>
+                </tr>
+                <tr>
+                  <td>Building enterprise services or MAUI apps</td>
+                  <td>.NET SDK</td>
+                  <td>gRPC and admin clients align well with Microsoft and mobile-adjacent stacks.</td>
+                </tr>
+                <tr>
+                  <td>Automating data workflows or analysis</td>
+                  <td>Python SDK</td>
+                  <td>Simple feature access and optional gRPC support fit notebooks, scripts, and pipelines.</td>
+                </tr>
+                <tr>
+                  <td>Wiring AI assistants or agents into data discovery</td>
+                  <td>MCP server</td>
+                  <td>Discovery, schema inspection, and filtered queries become tool-safe and explainable.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Field Workflows</p>
+          <h2>The next page after SDKs should be mobile, not a dead end.</h2>
+          <p>
+            If the April platform includes field collection, offline sync, and MAUI-first mobile experiences, the site has to say that directly.
+          </p>
+          <div class="action-row">
+            <a class="button button-primary" href="mobile.html">View Mobile</a>
+            <a class="button button-secondary" href="docs.html">Open Quickstarts</a>
+            <a class="button button-ghost" href="pricing.html">See Licensing</a>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,800 +1,849 @@
-@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Manrope:wght@400;500;600;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap");
 
 :root {
-  --bg: #f2f7f9;
-  --bg-strong: #e6f0f3;
-  --ink: #0e2433;
-  --muted: #4a6474;
-  --card: #ffffff;
-  --accent: #1f6f7a;
-  --accent-strong: #154b57;
-  --accent-soft: #dceff2;
-  --sun: #a8cfd8;
-  --border: #d3e2e6;
-  --shadow: 0 24px 60px rgba(14, 36, 51, 0.16);
-  --radius-lg: 28px;
-  --radius-md: 18px;
-  --radius-sm: 14px;
+  --bg: #f5efe3;
+  --surface: rgba(255, 251, 244, 0.84);
+  --surface-strong: #fffaf2;
+  --surface-dark: #15242a;
+  --ink: #13252f;
+  --muted: #586872;
+  --line: rgba(19, 37, 47, 0.12);
+  --accent: #157c68;
+  --accent-strong: #0f5f50;
+  --accent-soft: rgba(21, 124, 104, 0.12);
+  --spot: #eb6f2f;
+  --spot-soft: rgba(235, 111, 47, 0.14);
+  --shadow: 0 24px 60px rgba(19, 37, 47, 0.12);
+  --radius-lg: 32px;
+  --radius-md: 22px;
+  --radius-sm: 16px;
+  --max-width: 1180px;
   --font-display: "Fraunces", serif;
-  --font-body: "Manrope", sans-serif;
-  --fs-h1: clamp(2.6rem, 5vw, 3.8rem);
-  --fs-h2: clamp(1.85rem, 3vw, 2.2rem);
-  --fs-h3: 1.32rem;
-  --fs-body: 1rem;
-  --fs-small: 0.92rem;
-  --fs-eyebrow: 0.75rem;
-  --lh-tight: 1.1;
-  --lh-head: 1.2;
-  --lh-body: 1.7;
+  --font-body: "Space Grotesk", sans-serif;
+  --h1: clamp(3rem, 6vw, 5.5rem);
+  --h2: clamp(2rem, 3vw, 2.9rem);
+  --h3: 1.24rem;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: var(--font-body);
-  font-size: var(--fs-body);
-  line-height: var(--lh-body);
   color: var(--ink);
-  background: radial-gradient(circle at top left, #ffffff 0%, var(--bg) 45%, #e8f1f4 100%);
+  background:
+    radial-gradient(circle at top left, rgba(235, 111, 47, 0.12), transparent 36%),
+    radial-gradient(circle at top right, rgba(21, 124, 104, 0.16), transparent 34%),
+    linear-gradient(180deg, #fffaf2 0%, #f5efe3 44%, #f1e9db 100%);
   min-height: 100vh;
-  position: relative;
 }
 
 body::before {
   content: "";
   position: fixed;
   inset: 0;
-  background-image: linear-gradient(rgba(14, 36, 51, 0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(14, 36, 51, 0.04) 1px, transparent 1px);
-  background-size: 36px 36px;
-  opacity: 0.35;
+  background-image:
+    linear-gradient(rgba(19, 37, 47, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(19, 37, 47, 0.035) 1px, transparent 1px);
+  background-size: 34px 34px;
   pointer-events: none;
   z-index: -1;
 }
 
 a {
-  color: var(--accent);
+  color: inherit;
   text-decoration: none;
 }
 
-a:hover {
-  color: var(--accent-strong);
+img {
+  max-width: 100%;
+  display: block;
 }
 
-.page {
-  max-width: 1200px;
+.site-shell {
+  width: min(var(--max-width), calc(100% - 32px));
   margin: 0 auto;
-  padding: 32px 24px 80px;
+  padding: 24px 0 80px;
 }
 
-.nav {
+.topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 20;
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
   gap: 24px;
-  margin-bottom: 48px;
+  margin-bottom: 28px;
+  padding: 14px 18px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 250, 242, 0.8);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 10px 28px rgba(19, 37, 47, 0.08);
 }
 
-.logo {
-  font-family: var(--font-display);
-  font-size: 1.9rem;
-  font-weight: 700;
-  display: flex;
+.brand {
+  display: inline-flex;
   align-items: center;
-  gap: 14px;
-  color: var(--ink);
+  gap: 12px;
+  min-width: 0;
 }
 
-.logo img {
-  width: 128px;
-  height: 128px;
+.brand img {
+  width: 52px;
+  height: 52px;
   object-fit: contain;
+  border-radius: 14px;
 }
 
-.logo-text {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  line-height: 1;
+.brand-name {
+  display: block;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.02em;
 }
 
-.logo-sub {
-  font-size: 2.4rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
+.brand-tag {
+  display: block;
   color: var(--muted);
-  font-family: var(--font-body);
-  font-weight: 600;
+  font-size: 0.82rem;
 }
 
 .nav-links {
   display: flex;
-  gap: 20px;
-  font-weight: 600;
-  font-size: var(--fs-small);
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
   flex-wrap: wrap;
-  align-items: center;
 }
 
-.nav-cta {
-  padding: 8px 16px;
+.nav-links a {
+  padding: 10px 13px;
+  color: var(--muted);
   border-radius: 999px;
-  background: var(--accent);
-  color: #fff !important;
-  font-weight: 600;
-  font-size: var(--fs-small);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.nav-cta:hover {
-  color: #fff !important;
-  transform: translateY(-1px);
-  box-shadow: 0 8px 16px rgba(12, 107, 95, 0.2);
-}
-
-.hero {
-  padding: 48px 36px 72px;
-  border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, #ffffff 0%, var(--bg-strong) 55%, #e8f2f5 100%);
-  box-shadow: var(--shadow);
-  position: relative;
-  overflow: hidden;
-}
-
-.hero::before {
-  content: "";
-  position: absolute;
-  width: 320px;
-  height: 320px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(31, 111, 122, 0.22), transparent 70%);
-  top: -140px;
-  right: -120px;
-}
-
-.hero::after {
-  content: "";
-  position: absolute;
-  width: 280px;
-  height: 280px;
-  border-radius: 40% 60% 55% 45%;
-  background: radial-gradient(circle, rgba(168, 207, 216, 0.45), transparent 70%);
-  bottom: -160px;
-  left: -120px;
-}
-
-.hero-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 32px;
-  align-items: center;
-  position: relative;
-  z-index: 1;
-}
-
-.hero-text {
-  max-width: 640px;
-}
-
-.eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  font-size: var(--fs-eyebrow);
-  line-height: 1.4;
-  color: var(--muted);
-  font-weight: 600;
-  margin: 0 0 16px;
-}
-
-h1 {
-  font-family: var(--font-display);
-  font-size: var(--fs-h1);
-  line-height: var(--lh-tight);
-  letter-spacing: -0.01em;
-  margin: 0 0 18px;
-}
-
-.subhead {
-  font-size: var(--fs-body);
-  line-height: var(--lh-body);
+  font-size: 0.93rem;
   font-weight: 500;
-  color: var(--muted);
-  margin-bottom: 18px;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
-.subhead.secondary {
+.nav-links a:hover,
+.nav-links a.active {
+  background: rgba(19, 37, 47, 0.06);
   color: var(--ink);
 }
 
-.emphasis {
-  font-weight: 700;
-  color: var(--accent-strong);
-  background: rgba(31, 111, 122, 0.12);
-  padding: 0 6px;
-  border-radius: 8px;
-  box-decoration-break: clone;
-}
-
-.cta-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin: 20px 0 18px;
-}
-
-.btn {
-  padding: 12px 20px;
-  border-radius: 999px;
-  font-weight: 600;
-  font-size: var(--fs-small);
-  letter-spacing: 0.01em;
+.button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 10px;
+  padding: 13px 18px;
+  border-radius: 999px;
   border: 1px solid transparent;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
-.btn:hover {
+.button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(12, 107, 95, 0.2);
+  box-shadow: 0 14px 28px rgba(19, 37, 47, 0.12);
 }
 
-.btn.primary {
+.button-primary,
+.button-nav {
+  background: var(--ink);
+  color: #fff;
+}
+
+.button-secondary {
   background: var(--accent);
   color: #fff;
 }
 
-.btn.secondary {
-  background: #e6f0f3;
-  color: var(--ink);
-  border-color: #c7d9df;
+.button-ghost {
+  background: rgba(255, 255, 255, 0.55);
+  border-color: var(--line);
 }
 
-.btn.ghost {
-  background: transparent;
-  border-color: var(--border);
+.hero,
+.page-hero,
+.cta-band {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(19, 37, 47, 0.08);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(140deg, rgba(255, 250, 242, 0.95), rgba(245, 238, 226, 0.78)),
+    linear-gradient(140deg, rgba(21, 124, 104, 0.06), rgba(235, 111, 47, 0.08));
+  box-shadow: var(--shadow);
+}
+
+.hero::before,
+.page-hero::before,
+.cta-band::before {
+  content: "";
+  position: absolute;
+  width: 380px;
+  height: 380px;
+  right: -140px;
+  top: -170px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(21, 124, 104, 0.22), transparent 70%);
+}
+
+.hero::after,
+.page-hero::after,
+.cta-band::after {
+  content: "";
+  position: absolute;
+  width: 320px;
+  height: 320px;
+  left: -120px;
+  bottom: -170px;
+  border-radius: 42% 58% 59% 41%;
+  background: radial-gradient(circle, rgba(235, 111, 47, 0.18), transparent 70%);
+}
+
+.hero-home {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.9fr);
+  gap: 28px;
+  padding: 52px;
+}
+
+.page-hero {
+  padding: 48px;
+  margin-bottom: 28px;
+}
+
+.hero-copy,
+.hero-stack,
+.page-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  color: var(--accent-strong);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+h1,
+h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  letter-spacing: -0.03em;
+  line-height: 0.98;
+}
+
+h1 {
+  font-size: var(--h1);
+  max-width: 13ch;
+}
+
+h2 {
+  font-size: var(--h2);
+  max-width: 18ch;
+}
+
+h3 {
+  margin: 0 0 10px;
+  font-size: var(--h3);
+  line-height: 1.2;
+}
+
+.lede,
+.section-copy,
+.page-intro,
+.card p,
+.detail-card p,
+.stat-card p,
+.footer-copy,
+.surface-card p,
+.contact-copy p {
+  font-size: 1.02rem;
+  line-height: 1.7;
   color: var(--muted);
 }
 
-.cta-row .btn.primary {
-  padding: 13px 22px;
-  box-shadow: 0 14px 26px rgba(12, 107, 95, 0.18);
+.lede {
+  margin: 24px 0 0;
+  max-width: 62ch;
+  color: var(--ink);
 }
 
-.cta-row .btn.secondary,
-.cta-row .btn.ghost {
-  padding: 10px 18px;
-  font-size: var(--fs-small);
-  font-weight: 500;
-}
-
-.meta-list {
+.action-row,
+.pill-row,
+.contact-points {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  font-size: var(--fs-small);
-  line-height: 1.6;
-  color: var(--muted);
 }
 
-.meta-label {
-  font-weight: 700;
+.action-row {
+  margin-top: 28px;
+}
+
+.pill-row {
+  margin-top: 22px;
+}
+
+.pill {
+  padding: 9px 13px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(19, 37, 47, 0.08);
   color: var(--ink);
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: var(--fs-eyebrow);
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
-.hero-panel {
+.hero-stack {
+  display: grid;
+  gap: 16px;
+  align-content: start;
+}
+
+.surface-card,
+.card,
+.stat-card,
+.detail-card,
+.contact-form,
+.contact-copy {
+  border: 1px solid rgba(19, 37, 47, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 12px 32px rgba(19, 37, 47, 0.08);
+}
+
+.surface-card {
+  padding: 24px;
+}
+
+.diagram-shell {
+  padding: 18px;
+  border-radius: calc(var(--radius-lg) - 4px);
+  border: 1px solid rgba(19, 37, 47, 0.08);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.platform-diagram {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.diagram-title {
+  fill: var(--accent-strong);
+  font-family: var(--font-body);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.diagram-node {
+  stroke: rgba(19, 37, 47, 0.08);
+  stroke-width: 1.5;
+}
+
+.diagram-node-light {
+  fill: rgba(255, 255, 255, 0.92);
+}
+
+.diagram-node-highlight {
+  fill: #ebfaf6;
+}
+
+.diagram-node-spot {
+  fill: #fff2e9;
+}
+
+.diagram-node-title,
+.diagram-panel-title,
+.diagram-platform-title,
+.diagram-chip-title {
+  fill: var(--ink);
+  font-family: var(--font-body);
+  font-size: 19px;
+  font-weight: 700;
+}
+
+.diagram-node-copy,
+.diagram-panel-copy {
+  fill: var(--muted);
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.diagram-panel {
+  stroke-width: 1.5;
+}
+
+.diagram-panel-neutral {
+  fill: rgba(255, 255, 255, 0.92);
+  stroke: rgba(19, 37, 47, 0.08);
+}
+
+.diagram-panel-accent {
+  fill: rgba(21, 124, 104, 0.11);
+  stroke: rgba(21, 124, 104, 0.24);
+}
+
+.diagram-panel-spot {
+  fill: rgba(235, 111, 47, 0.12);
+  stroke: rgba(235, 111, 47, 0.24);
+}
+
+.diagram-platform-title,
+.diagram-platform-copy,
+.diagram-chip-title {
+  fill: #f6fbfb;
+}
+
+.diagram-platform-copy {
+  font-family: var(--font-body);
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.diagram-chip {
+  stroke-width: 1.2;
+}
+
+.diagram-chip-accent {
+  fill: rgba(21, 124, 104, 0.24);
+  stroke: rgba(113, 219, 190, 0.28);
+}
+
+.diagram-chip-spot {
+  fill: rgba(235, 111, 47, 0.2);
+  stroke: rgba(255, 199, 168, 0.32);
+}
+
+.diagram-line,
+.diagram-line-accent,
+.diagram-line-spot {
+  fill: none;
+  stroke-width: 3;
+}
+
+.diagram-line {
+  stroke: #37525d;
+}
+
+.diagram-line-accent {
+  stroke: var(--accent);
+}
+
+.diagram-line-spot {
+  stroke: var(--spot);
+}
+
+.surface-card-primary {
+  background:
+    linear-gradient(145deg, rgba(19, 37, 47, 0.96), rgba(20, 43, 52, 0.96)),
+    linear-gradient(145deg, rgba(21, 124, 104, 0.18), rgba(235, 111, 47, 0.14));
+  color: #fff;
+}
+
+.surface-card-primary p {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.surface-label,
+.card-kicker,
+.stat-title,
+.footer-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+.surface-label::before,
+.card-kicker::before,
+.stat-title::before,
+.footer-title::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--spot);
+}
+
+.surface-card-primary .surface-label::before {
+  background: #fff;
+}
+
+.section {
+  margin-top: 28px;
+  padding: 34px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(19, 37, 47, 0.08);
+  background: rgba(255, 251, 244, 0.76);
+  box-shadow: 0 10px 28px rgba(19, 37, 47, 0.06);
+}
+
+.section-contrast {
+  background:
+    linear-gradient(145deg, rgba(255, 246, 235, 0.78), rgba(231, 246, 240, 0.72));
+}
+
+.section-heading {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.section-heading h2 {
+  max-width: 16ch;
+}
+
+.stat-grid,
+.card-grid,
+.detail-grid,
+.contact-grid,
+.feature-grid {
   display: grid;
   gap: 16px;
 }
 
-.logo-banner {
-  margin-top: 24px;
-  padding: 12px 18px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: rgba(230, 240, 243, 0.7);
+.stat-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.card-grid-three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.detail-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card,
+.stat-card,
+.detail-card,
+.contact-copy,
+.contact-form {
+  padding: 24px;
+}
+
+.detail-card-accent {
+  background: linear-gradient(145deg, rgba(21, 124, 104, 0.12), rgba(255, 255, 255, 0.78));
+}
+
+.detail-card-spot {
+  background: linear-gradient(145deg, rgba(235, 111, 47, 0.12), rgba(255, 255, 255, 0.78));
+}
+
+.card-link,
+.stat-card,
+.detail-card {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px 18px;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
 }
 
-.logo-banner__label {
-  font-size: var(--fs-eyebrow);
-  letter-spacing: 0.26em;
-  text-transform: uppercase;
-  font-weight: 700;
-  color: var(--muted);
-}
-
-.logo-banner__logos {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.75;
-}
-
-.logo-badge {
-  font-size: var(--fs-small);
-  font-weight: 600;
-  color: var(--muted);
-  padding: 6px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(211, 226, 230, 0.9);
-  background: rgba(255, 255, 255, 0.7);
-  letter-spacing: 0.02em;
-}
-
-.logo-banner__logos img {
-  height: 28px;
-  width: auto;
-  filter: grayscale(1);
-  opacity: 0.75;
-}
-
-.diagram-section {
-  margin-top: 18px;
-  margin-bottom: 32px;
-  padding: 18px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: #ffffff;
-  box-shadow: 0 16px 36px rgba(14, 36, 51, 0.08);
-  display: flex;
-  justify-content: center;
-  gap: 18px;
-  align-items: stretch;
-}
-
-.diagram-section img,
-.diagram-section svg {
-  max-width: 100%;
-  height: auto;
-  border-radius: var(--radius-md);
-  display: block;
-}
-
-.diagram-mobile {
-  display: none;
-  background: #f6fafb;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  padding: 16px;
-  min-width: 280px;
-}
-
-.diagram-mobile h3 {
-  margin: 0 0 8px;
-  font-size: 1rem;
-  font-family: var(--font-display);
-}
-
-.panel-card {
-  background: var(--card);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
-  padding: 18px 20px;
-  box-shadow: 0 16px 32px rgba(14, 36, 51, 0.08);
-}
-
-.panel-card h3 {
-  margin-top: 0;
-  font-family: var(--font-display);
-  font-size: var(--fs-h3);
-  line-height: var(--lh-head);
-  font-weight: 600;
-}
-
-.panel-card.accent {
-  background: var(--accent-soft);
-  border-color: rgba(12, 107, 95, 0.2);
-}
-
-.section {
-  margin-top: 72px;
-}
-
-main .section:first-child {
-  margin-top: 0;
-}
-
-.section.highlight {
-  padding: 28px;
-  border-radius: var(--radius-lg);
-  background: linear-gradient(160deg, #f6fafb 0%, #e6f3f6 100%);
-  border: 1px solid var(--border);
-}
-
-.section-header {
-  margin-bottom: 24px;
-}
-
-.section-header h2 {
-  font-family: var(--font-display);
-  font-size: var(--fs-h2);
-  line-height: var(--lh-head);
-  letter-spacing: -0.01em;
-  margin-bottom: 10px;
-}
-
-.section-header p {
-  color: var(--muted);
-  font-size: var(--fs-body);
-  line-height: var(--lh-body);
-  margin: 0;
-  max-width: 720px;
-}
-
-.section-header p + p {
-  margin-top: 8px;
-}
-
-.grid {
-  display: grid;
-  gap: 2rem;
-  align-items: stretch;
-}
-
-.grid.two {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.grid.three {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.card {
-  background: var(--card);
-  padding: 20px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
-  height: 100%;
-  box-shadow: 0 12px 30px rgba(14, 36, 51, 0.06);
-}
-
-.card h3 {
-  margin-top: 0;
-  margin-bottom: 4px;
-  font-family: var(--font-display);
-  font-size: var(--fs-h3);
-  line-height: var(--lh-head);
-  font-weight: 600;
-}
-
-.card-subtitle {
-  margin: 0 0 12px;
-  font-size: var(--fs-small);
-  font-weight: 600;
-  color: var(--accent);
-  letter-spacing: 0.02em;
-}
-
-.highlight-card {
-  background: #ffffff;
-  border-color: rgba(12, 107, 95, 0.2);
+.card-link .text-link,
+.detail-card .text-link {
+  margin-top: auto;
 }
 
 .bullet-list {
-  list-style: none;
   margin: 16px 0 0;
   padding: 0;
+  list-style: none;
   display: grid;
   gap: 10px;
 }
 
 .bullet-list li {
   position: relative;
-  padding-left: 18px;
+  padding-left: 20px;
   color: var(--muted);
+  line-height: 1.6;
 }
 
 .bullet-list li::before {
   content: "";
   position: absolute;
   left: 0;
-  top: 0.55rem;
+  top: 0.63em;
   width: 8px;
   height: 8px;
   border-radius: 50%;
   background: var(--accent);
 }
 
-.pill-list,
-.pill-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 12px;
-}
-
-.pill {
-  display: inline-flex;
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: #edf6f8;
-  border: 1px solid var(--border);
-  font-size: var(--fs-small);
-  font-weight: 600;
-}
-
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 16px;
-}
-
-.stat-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  padding: 20px 12px;
-  border-radius: var(--radius-md);
-  background: #ffffff;
-  border: 1px solid var(--border);
-  box-shadow: 0 8px 20px rgba(14, 36, 51, 0.06);
-}
-
-.stat-number {
-  font-family: var(--font-body);
-  font-size: 1.6rem;
+.text-link {
+  color: var(--accent-strong);
   font-weight: 700;
-  color: var(--accent);
-  letter-spacing: -0.02em;
-  line-height: 1;
 }
 
-.stat-label {
-  font-size: var(--fs-small);
-  font-weight: 600;
+.text-link:hover {
   color: var(--ink);
-  margin-top: 8px;
 }
 
-.stat-detail {
-  font-size: 0.8rem;
-  color: var(--muted);
-  margin-top: 4px;
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid rgba(19, 37, 47, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.78);
 }
 
-.callout {
-  margin-top: 0;
-  padding: 14px 18px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  background: #ffffff;
-  font-weight: 600;
+table {
+  width: 100%;
+  border-collapse: collapse;
 }
 
-.section > * + .callout {
-  margin-top: 20px;
+th,
+td {
+  padding: 16px 18px;
+  border-bottom: 1px solid rgba(19, 37, 47, 0.08);
+  text-align: left;
+  vertical-align: top;
+  line-height: 1.55;
 }
-.note {
-  color: var(--muted);
-  font-size: var(--fs-small);
+
+th {
+  font-size: 0.86rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent-strong);
+}
+
+tr:last-child td {
+  border-bottom: 0;
+}
+
+code,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }
 
 pre {
-  background: #0e2433;
-  color: #eaf3f6;
-  padding: 16px;
-  border-radius: var(--radius-sm);
+  margin: 18px 0 0;
+  padding: 18px;
   overflow-x: auto;
-  font-size: 0.9rem;
-  line-height: 1.6;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(19, 37, 47, 0.1);
+  background: #10191d;
+  color: #edf6f5;
+  line-height: 1.55;
 }
 
-code {
-  font-family: "SFMono-Regular", "Menlo", "Consolas", "Liberation Mono", monospace;
-  font-size: 0.95em;
+.inline-code {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  font-size: 0.92rem;
 }
 
-.footer-cta {
-  background: linear-gradient(135deg, #0e2433 0%, #173a52 100%);
-  color: #eaf3f6;
-  padding: 36px;
-  border-radius: var(--radius-lg);
+.callout {
+  margin-top: 18px;
+  padding: 18px 20px;
+  border-left: 4px solid var(--spot);
+  border-radius: 18px;
+  background: rgba(235, 111, 47, 0.08);
+  color: var(--ink);
+  line-height: 1.65;
 }
 
-.footer-cta .section-header p {
-  color: rgba(234, 243, 246, 0.8);
-}
-
-.footer-cta .btn.primary {
-  background: #eaf3f6;
-  color: #0e2433;
-}
-
-.footer-cta .btn.secondary {
-  background: rgba(234, 243, 246, 0.12);
-  color: #eaf3f6;
-  border-color: rgba(234, 243, 246, 0.3);
-}
-
-.footer-cta .btn.ghost {
-  color: rgba(234, 243, 246, 0.8);
-  border-color: rgba(234, 243, 246, 0.4);
+.contact-grid {
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.96fr);
 }
 
 .contact-form {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  margin-bottom: 18px;
+  gap: 14px;
 }
 
 .contact-form label {
   display: grid;
-  gap: 6px;
-  font-size: var(--fs-small);
+  gap: 8px;
+  font-size: 0.92rem;
   font-weight: 600;
-}
-
-.contact-form .full-width {
-  grid-column: 1 / -1;
 }
 
 .contact-form input,
 .contact-form textarea {
   width: 100%;
-  border: 1px solid rgba(234, 243, 246, 0.35);
-  background: rgba(255, 255, 255, 0.12);
-  color: #eaf3f6;
-  border-radius: 10px;
-  padding: 10px 12px;
+  padding: 14px 15px;
+  border: 1px solid rgba(19, 37, 47, 0.14);
+  border-radius: 16px;
   font: inherit;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.86);
 }
 
-.contact-form input::placeholder,
-.contact-form textarea::placeholder {
-  color: rgba(234, 243, 246, 0.6);
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: 2px solid rgba(21, 124, 104, 0.18);
+  border-color: var(--accent);
 }
 
-.contact-form .btn {
-  justify-self: start;
+.contact-points span {
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: rgba(21, 124, 104, 0.1);
+  color: var(--accent-strong);
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
 .footer {
-  margin-top: 80px;
+  margin-top: 28px;
+  padding: 28px 20px 8px;
+}
+
+.footer-grid {
   display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  padding-top: 24px;
-  border-top: 1px solid var(--border);
-  color: var(--muted);
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 18px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(19, 37, 47, 0.12);
 }
 
 .footer a {
   display: block;
-  margin-bottom: 6px;
+  margin-bottom: 10px;
+  color: var(--muted);
 }
 
-.reveal {
-  opacity: 0;
-  transform: translateY(14px);
-  animation: fadeUp 0.8s ease forwards;
+.footer a:hover {
+  color: var(--ink);
 }
 
-.delay-1 {
-  animation-delay: 0.12s;
+.page-intro {
+  max-width: 60ch;
+  margin-top: 18px;
 }
 
-.delay-2 {
-  animation-delay: 0.2s;
+.mini-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
 }
 
-.delay-3 {
-  animation-delay: 0.28s;
+.note-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.delay-4 {
-  animation-delay: 0.36s;
+.note-card {
+  padding: 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(19, 37, 47, 0.08);
+  background: rgba(255, 255, 255, 0.72);
 }
 
-.delay-5 {
-  animation-delay: 0.44s;
+.note-card h3 {
+  margin-bottom: 10px;
 }
 
-.delay-6 {
-  animation-delay: 0.52s;
+.note-card p {
+  margin: 0;
+  line-height: 1.65;
+  color: var(--muted);
 }
 
-@keyframes fadeUp {
-  to {
-    opacity: 1;
-    transform: translateY(0);
+.cta-band {
+  margin-top: 28px;
+  padding: 32px;
+}
+
+.cta-band h2 {
+  max-width: 15ch;
+}
+
+.cta-band p {
+  max-width: 54ch;
+  line-height: 1.7;
+  color: var(--muted);
+}
+
+.stack {
+  display: grid;
+  gap: 16px;
+}
+
+@media (max-width: 1120px) {
+  .hero-home,
+  .contact-grid,
+  .stat-grid,
+  .card-grid-three,
+  .detail-grid,
+  .footer-grid,
+  .mini-grid,
+  .note-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .hero-home {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-grid {
+    grid-template-columns: 1fr;
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .reveal {
-    animation: none;
-    opacity: 1;
-    transform: none;
+@media (max-width: 760px) {
+  .site-shell {
+    width: min(var(--max-width), calc(100% - 20px));
+    padding-top: 16px;
   }
-}
 
-@media (max-width: 900px) {
-  .nav {
-    flex-direction: column;
+  .topbar,
+  .nav-links,
+  .hero-home,
+  .page-hero,
+  .section,
+  .cta-band {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  .topbar {
+    position: static;
+    border-radius: 26px;
     align-items: flex-start;
+    flex-direction: column;
   }
 
-  .hero {
-    padding: 32px 24px 56px;
-  }
-
-  .logo img {
-    width: 90px;
-    height: 90px;
-  }
-
-  .logo-banner {
-    border-radius: var(--radius-lg);
+  .nav-links {
     justify-content: flex-start;
   }
-}
 
-@media (max-width: 600px) {
-  .page {
-    padding: 24px 18px 64px;
+  h1 {
+    max-width: none;
   }
 
-  .logo {
-    gap: 10px;
-  }
-
-  .logo img {
-    width: 72px;
-    height: 72px;
-  }
-
-  .logo-sub {
-    font-size: 2rem;
-    letter-spacing: 0.14em;
-  }
-
-  .cta-row {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .footer-cta {
-    padding: 24px;
-  }
-
-  .logo-banner {
-    padding: 14px;
-  }
-
-  .logo-banner__label {
-    width: 100%;
-  }
-
-  .diagram-section {
-    padding: 14px;
-    flex-direction: column;
-  }
-
-  .diagram-section svg {
-    display: none;
-  }
-
-  .diagram-mobile {
-    display: block;
-  }
-
-  .contact-form {
+  .stat-grid,
+  .card-grid-three,
+  .detail-grid,
+  .contact-grid,
+  .mini-grid,
+  .note-grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the site around the April platform story with dedicated Platform, Protocols, SDKs, Mobile, Pricing, and Docs pages
- foreground MCP and gRPC as first-class protocol rails alongside compatibility surfaces
- make the pricing and licensing boundary explicit, including the private operator layer on top of the open-core platform

## Validation
- ./scripts/validate-site.sh
- ./scripts/build-dist.sh