### PR TITLE
fix: make site pages validation runner portable

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,11 @@
 name: Pages
 
 on:
+  pull_request:
+    branches:
+      - trunk
+    paths:
+      - "**"
   push:
     branches:
       - trunk
@@ -24,9 +29,10 @@ jobs:
       - name: Validate artifact security headers
         run: |
           test -f ./dist/_headers
-          rg -q "Content-Security-Policy: .*frame-ancestors 'none'" ./dist/_headers
+          grep -Eq "Content-Security-Policy: .*frame-ancestors 'none'" ./dist/_headers
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: validate
     runs-on: ubuntu-latest
     permissions:

--- a/scripts/validate-security-headers.sh
+++ b/scripts/validate-security-headers.sh
@@ -14,7 +14,7 @@ fail() {
 require_match() {
   local pattern="$1"
   local target="$2"
-  if ! rg -q "${pattern}" "${target}"; then
+  if ! grep -Eq "${pattern}" "${target}"; then
     fail "expected pattern '${pattern}' in ${target}"
   fi
 }
@@ -22,7 +22,7 @@ require_match() {
 require_no_match() {
   local pattern="$1"
   local target="$2"
-  if rg -q "${pattern}" "${target}"; then
+  if grep -Eq "${pattern}" "${target}"; then
     fail "unexpected pattern '${pattern}' in ${target}"
   fi
 }
@@ -46,7 +46,7 @@ if [[ -n "${header_check_url}" ]]; then
     fail "could not fetch response headers from ${header_check_url}"
   fi
 
-  if ! printf '%s\n' "${response_headers}" | rg -qi "^content-security-policy: .*frame-ancestors 'none'"; then
+  if ! printf '%s\n' "${response_headers}" | grep -Eqi "^content-security-policy: .*frame-ancestors 'none'"; then
     fail "live response from ${header_check_url} is missing CSP frame-ancestors enforcement"
   fi
 fi

--- a/scripts/validate-site.sh
+++ b/scripts/validate-site.sh
@@ -27,7 +27,7 @@ done
 require_match() {
   local pattern="$1"
   local target="$2"
-  if ! rg -q "${pattern}" "${target}"; then
+  if ! grep -Eq "${pattern}" "${target}"; then
     echo "Validation failed: expected pattern '${pattern}' in ${target}" >&2
     exit 1
   fi
@@ -36,7 +36,7 @@ require_match() {
 require_no_match() {
   local pattern="$1"
   local target="$2"
-  if rg -q "${pattern}" "${target}"; then
+  if grep -Eq "${pattern}" "${target}"; then
     echo "Validation failed: unexpected pattern '${pattern}' in ${target}" >&2
     exit 1
   fi

--- a/scripts/validate-workflow-pinning.sh
+++ b/scripts/validate-workflow-pinning.sh
@@ -47,7 +47,7 @@ while IFS= read -r workflow_file; do
       echo "Validation failed: ${workflow_file}:${line_number} uses '${action_ref}' which is not pinned to a 40-character commit SHA" >&2
       failures=$((failures + 1))
     fi
-  done < <(rg --line-number --no-heading "^[[:space:]]*uses:[[:space:]]+" "${workflow_file}")
+  done < <(grep -En "^[[:space:]]*uses:[[:space:]]+" "${workflow_file}")
 done < <(find "${workflows_dir}" -maxdepth 1 -type f \( -name "*.yml" -o -name "*.yaml" \) | sort)
 
 if (( workflow_count == 0 )); then


### PR DESCRIPTION
## Summary
- replace local ripgrep assumptions with runner-safe grep checks in site validation scripts
- run the Pages validation job on pull requests so deployment breakage is caught before merge
- keep the merged April platform redesign on trunk as the content being validated

## Validation
- ./scripts/validate-site.sh
- ./scripts/build-dist.sh