### PR TITLE
fix: reset public site copy

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -36,9 +36,9 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Docs</p>
-          <h1>One clean quickstart path beats a vague “read the docs” link.</h1>
+          <h1>Start Honua in Docker, make a request, and pick an SDK.</h1>
           <p class="page-intro">
-            This page is the minimum docs hub: start the server, make a first request, install one SDK, and then branch into deeper references for protocols, migration, or mobile.
+            This page gives the fastest Docker-first path into Honua: start the server, make a first request, install one SDK, and then branch into deeper references for protocols, migration, or mobile.
           </p>
         </section>
 
@@ -50,9 +50,19 @@
           <article class="card">
             <p class="card-kicker">Step 1</p>
             <h3>Run the server</h3>
-            <pre><code>git clone https://github.com/honua-io/honua-server.git
-cd honua-server
-docker compose up -d
+            <pre><code>docker network create honua
+
+docker run -d --name honua-postgis --network honua \
+  -e POSTGRES_DB=honua \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=postgres \
+  postgis/postgis:17-3.6
+
+docker run -d --name honua-server --network honua -p 8080:8080 \
+  -e ConnectionStrings__DefaultConnection="Host=honua-postgis;Database=honua;Username=postgres;Password=postgres" \
+  -e HONUA_ADMIN_PASSWORD="change-me" \
+  honuaio/honua-server:latest
+
 curl http://localhost:8080/healthz/ready</code></pre>
           </article>
           <article class="card" style="margin-top: 16px;">

--- a/index.html
+++ b/index.html
@@ -62,13 +62,12 @@
       <main>
         <section class="hero hero-home">
           <div class="hero-copy">
-            <p class="eyebrow">April 1 Platform Goal</p>
-            <h1>Compatibility for migration. gRPC for apps. MCP for agents.</h1>
+            <p class="eyebrow">Cloud-Native Geospatial Platform</p>
+            <h1>A cloud-native GIS platform for migration, apps, mobile, and agents.</h1>
             <p class="lede">
-              Honua lets teams keep ArcGIS-style and standards-based clients working while adding two newer rails:
-              <strong>`gRPC`</strong> for high-throughput app and mobile workflows, and <strong>`MCP`</strong> for
-              agent-native discovery and query workflows. One cloud-native platform, one operational model, no
-              per-user fees or protocol taxes.
+              Honua is a cloud-native geospatial platform and GIS runtime. It keeps ArcGIS-style and standards-based
+              clients working, adds <strong>gRPC</strong> for app and mobile performance, and adds <strong>MCP</strong>
+              for agent-native discovery and query workflows. One operational model, no per-user fees or protocol taxes.
             </p>
             <div class="action-row">
               <a class="button button-primary" href="protocols.html">See the Protocol Story</a>
@@ -85,16 +84,16 @@
               <span class="pill">Mobile SDK</span>
             </div>
             <div class="callout hero-callout">
-              Migration compatibility is the on-ramp. `gRPC` and `MCP` are the forward edge.
+              Keep existing GIS clients working while giving developers, mobile teams, and agents modern access rails.
             </div>
           </div>
 
           <div class="hero-stack">
             <article class="surface-card surface-card-primary">
-              <p class="surface-label">Launch Narrative</p>
-              <h2>Three rails, one platform.</h2>
+              <p class="surface-label">What Honua Is</p>
+              <h2>One platform with three integration layers.</h2>
               <p>
-                Compatibility keeps migrations low-risk. `gRPC` makes apps and mobile feel modern. `MCP` opens the
+                Compatibility keeps migrations low-risk. gRPC makes apps and mobile feel modern. MCP opens the
                 platform to coding agents and assistants.
               </p>
             </article>
@@ -103,7 +102,7 @@
               <ul class="bullet-list">
                 <li>Replace brittle legacy GIS stacks without breaking existing clients.</li>
                 <li>Adopt open standards and typed SDKs while preserving ArcGIS and OGC entry points.</li>
-                <li>Move app, mobile, and agent workflows onto `gRPC` and `MCP` instead of keeping everything trapped in legacy REST patterns.</li>
+                <li>Move app, mobile, and agent workflows onto gRPC and MCP instead of keeping everything trapped in legacy REST patterns.</li>
               </ul>
             </article>
           </div>
@@ -112,7 +111,7 @@
         <section class="section stat-section">
           <div class="section-heading">
             <p class="eyebrow">Platform Snapshot</p>
-            <h2>The site should reflect the whole platform surface, not one repo.</h2>
+            <h2>One platform across migration, developers, mobile, and AI.</h2>
           </div>
           <div class="stat-grid">
             <article class="stat-card">
@@ -137,9 +136,9 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Architecture</p>
-            <h2>The diagram should explain why Honua is different.</h2>
+            <h2>How Honua fits together.</h2>
             <p class="section-copy">
-              Compatibility gets a team in the door. The deeper innovation is the layered access model: compatibility protocols for migration, gRPC for high-throughput application and mobile paths, and MCP for agent-native discovery and query workflows.
+              Existing GIS clients enter through compatibility protocols. New apps and mobile clients use gRPC. Agents use MCP. All three land on the same runtime and control plane.
             </p>
           </div>
           <div class="diagram-shell">
@@ -250,7 +249,7 @@
             </article>
             <article class="note-card">
               <h3>gRPC and MCP are the forward wedge</h3>
-              <p>`gRPC` is the fast path for apps and mobile. `MCP` is the safe path for agents. Those two rails are what make Honua feel contemporary rather than merely compatible.</p>
+              <p>gRPC is the fast path for apps and mobile. MCP is the safe path for agents. Those two rails are what make Honua feel contemporary rather than merely compatible.</p>
             </article>
           </div>
         </section>
@@ -258,15 +257,15 @@
         <section class="section section-contrast">
           <div class="section-heading">
             <p class="eyebrow">Commercial Model</p>
-            <h2>The pricing story should land on the homepage.</h2>
+            <h2>Pricing and licensing are part of the product.</h2>
             <p class="section-copy">
-              Visitors should understand the economic shape immediately: no seat tax, no protocol tax, and no need to buy separate client access just to use the platform.
+              Honua is designed to avoid the seat-count and protocol-gating model common in legacy GIS stacks.
             </p>
           </div>
           <div class="mini-grid">
             <article class="note-card">
               <h3>No seat pricing</h3>
-              <p>Adding analysts, viewers, or field operators should not force another licensing negotiation.</p>
+              <p>Adding analysts, viewers, or field operators does not force another licensing negotiation.</p>
             </article>
             <article class="note-card">
               <h3>No protocol or SDK add-ons</h3>
@@ -274,7 +273,7 @@
             </article>
             <article class="note-card">
               <h3>Pay for depth, not permission</h3>
-              <p>Commercial tiers should map to distributed runtime capability, governance, support, and enterprise readiness.</p>
+              <p>Commercial tiers map to distributed runtime capability, governance, support, and enterprise readiness.</p>
             </article>
             <article class="note-card">
               <h3>Clear license split</h3>
@@ -286,10 +285,9 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">What Ships Together</p>
-            <h2>The April story is a platform story.</h2>
+            <h2>One platform, multiple surfaces.</h2>
             <p class="section-copy">
-              The homepage needs to make the product legible in one scan: what runs, how you integrate, how you migrate,
-              how you deploy, and how licensing works.
+              In one scan: what runs, how you integrate, how you migrate, how you deploy, and how licensing works.
             </p>
           </div>
           <div class="card-grid card-grid-three">
@@ -318,7 +316,7 @@
             </article>
             <article class="card">
               <p class="card-kicker">AI and Agents</p>
-              <h3>MCP belongs on the front page</h3>
+              <h3>MCP as a first-class surface</h3>
               <p>
                 MCP is a first-class part of the platform story for discovery, schema inspection, query workflows, and
                 agent integration.
@@ -328,7 +326,7 @@
               <p class="card-kicker">Migration</p>
               <h3>Esri and GeoServer replacement lane</h3>
               <p>
-                The public narrative should center migration proof: compatibility, standards, pricing clarity, and staged adoption.
+                Compatibility, standards, pricing clarity, and staged adoption keep replacement projects credible.
               </p>
             </article>
             <article class="card">
@@ -345,16 +343,16 @@
           <div class="detail-grid">
             <article class="detail-card">
               <p class="eyebrow">Proof</p>
-              <h2>Compatibility and conformance need dedicated room.</h2>
+              <h2>Compatibility and conformance have dedicated room.</h2>
               <p>
                 Honua already carries launch-facing compatibility and conformance evidence across OGC API, WMS, WMTS,
-                GeoServices-style surfaces, and SDK compatibility guidance. The site should expose that proof, not bury it.
+                GeoServices-style surfaces, and SDK compatibility guidance. That proof is part of the product story, not an appendix.
               </p>
               <a class="text-link" href="protocols.html">Explore protocol coverage</a>
             </article>
             <article class="detail-card">
               <p class="eyebrow">Licensing</p>
-              <h2>Licensing should be explicit, not implied.</h2>
+              <h2>Licensing is explicit, not implied.</h2>
               <p>
                 The server follows an open-core ELv2 model while the official SDKs and mobile/tooling repos use Apache 2.0.
                 That distinction matters for trust, procurement, and migration conversations.

--- a/mobile.html
+++ b/mobile.html
@@ -36,17 +36,17 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Mobile</p>
-          <h1>Field workflows should be visible at the top level.</h1>
+          <h1>Field workflows are part of the platform.</h1>
           <p class="page-intro">
-            Mobile is no longer an afterthought. The April platform story includes MAUI-first field collection,
-            offline GeoPackage sync, forms, background upload, and gRPC-first performance for operational teams.
+            Honua includes a MAUI-first mobile lane with offline GeoPackage sync, forms, background upload, and
+            gRPC-first performance for operational teams.
           </p>
         </section>
 
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Mobile Positioning</p>
-            <h2>What the site needs to say clearly.</h2>
+            <h2>What the mobile surface includes.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
@@ -77,7 +77,7 @@
             <article class="card">
               <p class="card-kicker">Economics</p>
               <h3>No per-user mobile tax</h3>
-              <p>The site should say directly that the mobile story is not priced like a per-seat field app subscription stack.</p>
+              <p>Mobile workflows do not carry a separate per-seat field subscription tax.</p>
             </article>
           </div>
         </section>
@@ -85,7 +85,7 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Mobile Stack</p>
-            <h2>What is part of the current mobile surface.</h2>
+            <h2>What ships in the current mobile surface.</h2>
           </div>
           <div class="table-wrap">
             <table>
@@ -110,7 +110,7 @@
                 <tr>
                   <td>Honua.Mobile.Offline</td>
                   <td>GeoPackage storage and sync engine</td>
-                  <td>Offline-first behavior should be a headline feature, not buried implementation detail.</td>
+                  <td>Offline-first behavior is a headline feature, not buried implementation detail.</td>
                 </tr>
                 <tr>
                   <td>Honua.Mobile.Maui</td>
@@ -135,7 +135,7 @@
               <p class="eyebrow">Pricing</p>
               <h2>Licensing becomes part of the field story.</h2>
               <p>
-                Field buyers are sensitive to per-user mobile pricing. The site should connect mobile capabilities to the broader no-per-user posture.
+                Field buyers are sensitive to per-user mobile pricing. Honua ties mobile capabilities to the same no-per-user posture as the rest of the platform.
               </p>
             </article>
           </div>

--- a/platform.html
+++ b/platform.html
@@ -36,10 +36,10 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Platform</p>
-          <h1>The April 1 story is a platform, not a landing page.</h1>
+          <h1>Honua is a platform, not just a server.</h1>
           <p class="page-intro">
             Honua combines a multi-protocol server runtime, typed SDKs, mobile field foundations, MCP tooling,
-            migration helpers, and cloud-native deployment options. The public site should present those as one coherent system.
+            migration helpers, and cloud-native deployment options in one coherent system.
           </p>
         </section>
 
@@ -48,7 +48,7 @@
             <p class="eyebrow">Differentiation</p>
             <h2>Compatibility gets attention. gRPC and MCP create the forward edge.</h2>
             <p class="section-copy">
-              The site should make one strategic distinction very clear: GeoServices REST and OGC compatibility win trust during migration, while `gRPC` and `MCP` are the modern rails that make Honua feel like a next-generation platform.
+              GeoServices REST and OGC compatibility win trust during migration, while gRPC and MCP are the modern rails that make Honua feel like a next-generation platform.
             </p>
           </div>
           <div class="detail-grid">
@@ -56,7 +56,7 @@
               <p class="eyebrow">gRPC</p>
               <h2>Fast path for apps, SDKs, and mobile</h2>
               <p>
-                `gRPC` is the typed binary rail for application builders and field workflows. It should read as part of the product’s technical edge, not as a buried implementation detail.
+                gRPC is the typed binary rail for application builders and field workflows. It is part of the product’s technical edge, not a buried implementation detail.
               </p>
             </article>
             <article class="detail-card detail-card-spot">
@@ -72,7 +72,7 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Core Layers</p>
-            <h2>What the platform needs to say clearly.</h2>
+            <h2>The platform in one view.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
@@ -114,7 +114,7 @@
               <p class="card-kicker">Operations</p>
               <h3>Deploy where the team already runs</h3>
               <p>
-                Docker, Kubernetes, AWS, Azure, serverless, and infrastructure-as-code should stay visible because deployment freedom is part of the product.
+                Docker, Kubernetes, AWS, Azure, serverless, and infrastructure-as-code stay visible because deployment freedom is part of the product.
               </p>
             </article>
           </div>
@@ -123,7 +123,7 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Surface Map</p>
-            <h2>The public story should connect repos into one product.</h2>
+            <h2>How the product surfaces fit together.</h2>
           </div>
           <div class="table-wrap">
             <table>
@@ -131,7 +131,7 @@
                 <tr>
                   <th>Surface</th>
                   <th>Role in the platform</th>
-                  <th>What the site should emphasize</th>
+                  <th>What the product emphasizes</th>
                 </tr>
               </thead>
               <tbody>
@@ -178,15 +178,15 @@
         <section class="section section-contrast">
           <div class="note-grid">
             <article class="note-card">
-              <h3>What the old site underplays</h3>
+              <h3>Why this is broader than a server</h3>
               <p>
-                MCP, mobile, gRPC, SDK breadth, licensing nuance, and the control-plane arc were all either absent or too buried to carry the actual product story.
+                MCP, mobile, gRPC, SDK breadth, licensing nuance, and the control-plane arc make Honua read as a platform, not a single runtime.
               </p>
             </article>
             <article class="note-card">
-              <h3>What this redesign changes</h3>
+              <h3>What ties it together</h3>
               <p>
-                The site becomes a map of the platform: protocol surface, developer surface, mobile surface, procurement surface, migration surface, and a clearly separated private operator layer.
+                The platform spans protocol surface, developer surface, mobile surface, procurement surface, migration surface, and a clearly separated private operator layer.
               </p>
             </article>
           </div>

--- a/pricing.html
+++ b/pricing.html
@@ -38,18 +38,19 @@
           <p class="eyebrow">Pricing and Licensing</p>
           <h1>No seat tax. No protocol tax. No SDK tax.</h1>
           <p class="page-intro">
-            The site needs a plain-language pricing page because buyers will not infer the right story from a single tagline.
-            Honua uses an open-core model with clear runtime boundaries: no per-user fees, no protocol gating, no add-on SDK licensing, and no credit-style meter. Commercial tiers start when a team needs coordinated scale, streaming depth, governance, and enterprise support.
+            Honua uses an open-core model with clear runtime boundaries: no per-user fees, no protocol gating,
+            no add-on SDK licensing, and no credit-style meter. Commercial tiers start when a team needs coordinated
+            scale, streaming depth, governance, and enterprise support.
           </p>
           <div class="callout">
-            You should not pay more because you added more users, more client apps, more standards, more field devices, or more agent workflows.
+            You do not pay more because you added more users, more client apps, more standards, more field devices, or more agent workflows.
           </div>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">What Buyers Should Understand Fast</p>
-            <h2>The model should be legible in one scan.</h2>
+            <p class="eyebrow">Buyer Snapshot</p>
+            <h2>The model is legible in one scan.</h2>
           </div>
           <div class="mini-grid">
             <article class="note-card">
@@ -74,7 +75,7 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">What We Refuse To Monetize</p>
-            <h2>The posture should be explicit.</h2>
+            <h2>The commercial boundary is explicit.</h2>
           </div>
           <div class="mini-grid">
             <article class="note-card">
@@ -83,7 +84,7 @@
             </article>
             <article class="note-card">
               <h3>Protocols</h3>
-              <p>GeoServices REST, OGC API, OData, tiles, and SDK access should stay visible because they are part of adoption, not premium upsell bait.</p>
+              <p>GeoServices REST, OGC API, OData, tiles, and SDK access stay visible because they are part of adoption, not premium upsell bait.</p>
             </article>
             <article class="note-card">
               <h3>SDKs and client surfaces</h3>
@@ -91,7 +92,7 @@
             </article>
             <article class="note-card">
               <h3>What commercial tiers actually cover</h3>
-              <p>Higher editions should map to distributed coordination, streaming depth, governance, support, and enterprise controls.</p>
+              <p>Higher editions map to distributed coordination, streaming depth, governance, support, and enterprise controls.</p>
             </article>
           </div>
         </section>
@@ -125,7 +126,7 @@
               <p class="eyebrow">What You Never Pay For</p>
               <h2>User count, protocol usage, or client access.</h2>
               <p>
-                Honua should not feel like a platform where every new viewer, field operator, protocol, or SDK becomes a separate purchasing event. That is exactly the pricing shape many teams are trying to leave behind.
+                Honua is designed to avoid the pricing shape many teams are trying to leave behind: every new viewer, field operator, protocol, or SDK becoming a separate purchasing event.
               </p>
             </article>
             <article class="detail-card">
@@ -216,13 +217,13 @@
                 <tr>
                   <td>Site and collateral</td>
                   <td>Apache 2.0</td>
-                  <td>The public trust layer should be transparent and easy to reuse internally.</td>
+                  <td>The public trust layer is transparent and easy to reuse internally.</td>
                 </tr>
               </tbody>
             </table>
           </div>
           <div class="callout">
-            The pricing page should answer procurement questions directly: no per-user fees, no credit system, no protocol gating, and clear explanation of what ELv2 means in practice.
+            This page answers procurement questions directly: no per-user fees, no credit system, no protocol gating, and a clear explanation of what ELv2 means in practice.
           </div>
         </section>
 
@@ -233,14 +234,14 @@
               <h2>What buyers actually compare.</h2>
               <p>
                 Most migration buyers are comparing against per-user ArcGIS cost growth, extension taxes, and operational drag.
-                The site should speak that language directly.
+                Honua speaks that language directly.
               </p>
             </article>
             <article class="detail-card">
               <p class="eyebrow">Trust</p>
               <h2>Licensing is part of trust, not fine print.</h2>
               <p>
-                If the public story is unclear about license boundaries, procurement and legal will assume the worst. This page should remove that ambiguity.
+                If the public story is unclear about license boundaries, procurement and legal will assume the worst. This page removes that ambiguity.
               </p>
             </article>
           </div>

--- a/protocols.html
+++ b/protocols.html
@@ -38,8 +38,8 @@
           <p class="eyebrow">Protocols</p>
           <h1>Compatibility gets teams in. gRPC and MCP show what is actually new.</h1>
           <p class="page-intro">
-            Honua should be legible as the place where GeoServices REST, OGC API, OData, gRPC, MCP, and cloud-native tiles meet.
-            But the protocol page should not treat every surface as equally strategic. Compatibility explains migration. `gRPC` and `MCP` explain why the platform is modern.
+            Honua brings GeoServices REST, OGC API, OData, gRPC, MCP, and cloud-native tiles together in one runtime.
+            Compatibility explains migration. gRPC and MCP explain why the platform is modern.
           </p>
         </section>
 
@@ -81,7 +81,7 @@
             <p class="eyebrow">Protocol Diagram</p>
             <h2>How the protocol layers actually fit together.</h2>
             <p class="section-copy">
-              The site needs a visual that separates migration compatibility from forward-looking integration rails. This makes it easier to see why `gRPC` and `MCP` matter without discarding the compatibility story.
+              This visual separates migration compatibility from forward-looking integration rails. It shows why gRPC and MCP matter without discarding the compatibility story.
             </p>
           </div>
           <div class="diagram-shell">
@@ -202,12 +202,12 @@
             <article class="card">
               <p class="card-kicker">gRPC</p>
               <h3>Binary transport for high-throughput paths</h3>
-              <p>`gRPC` is the modern app and mobile rail. Unary support is part of the open surface. Streaming is the scale and performance unlock that differentiates paid runtime tiers.</p>
+              <p>gRPC is the modern app and mobile rail. Unary support is part of the open surface. Streaming is the scale and performance unlock that differentiates paid runtime tiers.</p>
             </article>
             <article class="card">
               <p class="card-kicker">MCP</p>
               <h3>Agent-native access</h3>
-              <p>`MCP` gives AI assistants and agents a safe path to discovery, schema inspection, and query workflows on top of Honua data, and it should read as a platform innovation rather than a footnote.</p>
+              <p>MCP gives AI assistants and agents a safe path to discovery, schema inspection, and query workflows on top of Honua data. It is a platform innovation, not a footnote.</p>
             </article>
             <article class="card">
               <p class="card-kicker">Tiles and Classic OGC</p>
@@ -250,13 +250,13 @@
                 <tr>
                   <td>SDK access</td>
                   <td>JavaScript, .NET, Python, and mobile remain visible and accessible</td>
-                  <td>Paid tiers should deepen scale, operations, and governance instead of hiding the SDKs</td>
+                  <td>Paid tiers deepen scale, operations, and governance instead of hiding the SDKs</td>
                 </tr>
               </tbody>
             </table>
           </div>
           <div class="callout">
-            The public pricing story should reinforce the protocol rule: buyers are paying for runtime coordination,
+            The public pricing story reinforces the protocol rule: buyers are paying for runtime coordination,
             streaming depth, governance, and support, not for permission to speak a protocol.
           </div>
         </section>
@@ -265,10 +265,10 @@
           <div class="detail-grid">
             <article class="detail-card">
               <p class="eyebrow">Proof</p>
-              <h2>Conformance should be visible.</h2>
+              <h2>Conformance is visible.</h2>
               <p>
                 The launch compatibility contract already carries concrete OGC API, WMS, and WMTS coverage evidence.
-                That proof should live near the protocol story, not disappear into deep docs.
+                That proof lives near the protocol story instead of disappearing into deep docs.
               </p>
             </article>
             <article class="detail-card">

--- a/sdks.html
+++ b/sdks.html
@@ -36,10 +36,9 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">SDKs</p>
-          <h1>The developer story needs first-class pages.</h1>
+          <h1>Official SDKs for JavaScript, .NET, Python, and agent workflows.</h1>
           <p class="page-intro">
-            Honua should look like a platform developers can actually build on: typed clients, migration tooling, agent access,
-            compatibility guidance, and direct install paths.
+            Honua gives developers typed clients, migration tooling, agent access, compatibility guidance, and direct install paths.
           </p>
         </section>
 
@@ -75,7 +74,7 @@ pip install honua-sdk[grpc]</code></pre>
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Beyond Basic SDKs</p>
-            <h2>The public developer story is broader than package installs.</h2>
+            <h2>The developer surface is broader than package installs.</h2>
           </div>
           <div class="mini-grid">
             <article class="note-card">
@@ -93,13 +92,13 @@ pip install honua-sdk[grpc]</code></pre>
             <article class="note-card">
               <h3>Versioning and compatibility</h3>
               <p>
-                Server and SDK compatibility contracts are part of the product trust layer. The site should surface those expectations instead of assuming developers will infer them.
+                Server and SDK compatibility contracts are part of the product trust layer. This site shows those expectations directly.
               </p>
             </article>
             <article class="note-card">
               <h3>Quickstarts</h3>
               <p>
-                The docs surface should let a team install one SDK, make one authenticated call, and understand where to go next without hunting across repos.
+                The docs surface lets a team install one SDK, make one authenticated call, and understand where to go next without hunting across repos.
               </p>
             </article>
           </div>
@@ -147,9 +146,9 @@ pip install honua-sdk[grpc]</code></pre>
 
         <section class="cta-band">
           <p class="eyebrow">Field Workflows</p>
-          <h2>The next page after SDKs should be mobile, not a dead end.</h2>
+          <h2>Mobile is a first-class continuation of the SDK story.</h2>
           <p>
-            If the April platform includes field collection, offline sync, and MAUI-first mobile experiences, the site has to say that directly.
+            Field collection, offline sync, and MAUI-first mobile experiences are part of the platform, not an afterthought.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="mobile.html">View Mobile</a>


### PR DESCRIPTION
## Summary
- replace internal roadmap/workshop language with direct product copy on the main site pages
- fix the docs quickstart to use a Docker-first startup path instead of cloning the repo
- keep the refreshed site structure while making the homepage explain what Honua actually is

## Validation
- ./scripts/validate-site.sh
- ./scripts/build-dist.sh
