### PR TITLE
fix: tighten public site copy and simplify diagrams

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -38,7 +38,7 @@
           <p class="eyebrow">Docs</p>
           <h1>Start Honua in Docker, make a request, and pick an SDK.</h1>
           <p class="page-intro">
-            This page gives the fastest Docker-first path into Honua: start the server, make a first request, install one SDK, and then branch into deeper references for protocols, migration, or mobile.
+            This page gives the fastest Docker-first path into Honua: start the server, make a first request, install one SDK, and then jump into deeper references for protocols, migration, or mobile.
           </p>
         </section>
 
@@ -84,12 +84,12 @@ const result = await client.queryFeatures({ serviceId: "parcels", layerId: 0 });
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Deeper Paths</p>
-            <h2>Choose the docs lane that matches your goal.</h2>
+            <h2>Choose the docs path that matches your goal.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card card-link">
               <h3>Platform docs</h3>
-              <p>Deployment, compatibility, standards references, and launch-facing product docs.</p>
+              <p>Deployment guides, compatibility references, standards documentation, and product docs.</p>
               <a
                 class="text-link"
                 href="https://honua.gitbook.io/honuaio/"

--- a/index.html
+++ b/index.html
@@ -70,11 +70,11 @@
               for agent-native discovery and query workflows. One operational model, no per-user fees or protocol taxes.
             </p>
             <div class="action-row">
-              <a class="button button-primary" href="protocols.html">See the Protocol Story</a>
-              <a class="button button-secondary" href="docs.html">Start with Docs</a>
-              <a class="button button-ghost" href="pricing.html">See Licensing</a>
+              <a class="button button-primary" href="protocols.html">See Supported APIs</a>
+              <a class="button button-secondary" href="docs.html">Get Started</a>
+              <a class="button button-ghost" href="pricing.html">Pricing and Licensing</a>
             </div>
-            <div class="pill-row" aria-label="Launch surface">
+            <div class="pill-row" aria-label="Core capabilities">
               <span class="pill">GeoServices REST</span>
               <span class="pill">OGC API</span>
               <span class="pill">OData v4</span>
@@ -91,10 +91,9 @@
           <div class="hero-stack">
             <article class="surface-card surface-card-primary">
               <p class="surface-label">What Honua Is</p>
-              <h2>One platform with three integration layers.</h2>
+              <h2>Keep current GIS clients. Build faster apps. Add agent access.</h2>
               <p>
-                Compatibility keeps migrations low-risk. gRPC makes apps and mobile feel modern. MCP opens the
-                platform to coding agents and assistants.
+                Compatibility keeps migrations low-risk. gRPC improves application and mobile performance. MCP gives coding agents and assistants a supported way to work with geospatial data.
               </p>
             </article>
             <article class="surface-card">
@@ -111,16 +110,16 @@
         <section class="section stat-section">
           <div class="section-heading">
             <p class="eyebrow">Platform Snapshot</p>
-            <h2>One platform across migration, developers, mobile, and AI.</h2>
+            <h2>Everything teams need to adopt, migrate, and build.</h2>
           </div>
           <div class="stat-grid">
             <article class="stat-card">
               <span class="stat-title">Protocols</span>
-              <p>GeoServices REST, OGC API, OData v4, vector tiles, WMS, WMTS, plus `gRPC` and `MCP` as the modern integration rails.</p>
+              <p>GeoServices REST, OGC API, OData v4, vector tiles, WMS, WMTS, plus gRPC and MCP for newer application and agent workflows.</p>
             </article>
             <article class="stat-card">
-              <span class="stat-title">Developer Surface</span>
-              <p>JavaScript, .NET, Python, migration tooling, and an MCP server package for agent workflows.</p>
+              <span class="stat-title">SDKs</span>
+              <p>JavaScript, .NET, Python, migration tooling, and an MCP package for agent workflows.</p>
             </article>
             <article class="stat-card">
               <span class="stat-title">Mobile</span>
@@ -138,119 +137,39 @@
             <p class="eyebrow">Architecture</p>
             <h2>How Honua fits together.</h2>
             <p class="section-copy">
-              Existing GIS clients enter through compatibility protocols. New apps and mobile clients use gRPC. Agents use MCP. All three land on the same runtime and control plane.
+              Existing GIS clients enter through compatibility APIs. New apps and mobile clients use gRPC. Agents use MCP. All three paths reach the same Honua runtime and admin APIs.
             </p>
           </div>
-          <div class="diagram-shell">
-            <svg class="platform-diagram" viewBox="0 0 1140 620" role="img" aria-label="Diagram showing legacy clients, modern apps, mobile apps, and AI agents connecting to Honua through compatibility protocols, gRPC, and MCP">
-              <defs>
-                <linearGradient id="inkPanel" x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" stop-color="#14252c" />
-                  <stop offset="100%" stop-color="#203b44" />
-                </linearGradient>
-                <linearGradient id="mintPanel" x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" stop-color="#dff4ee" />
-                  <stop offset="100%" stop-color="#eef8f4" />
-                </linearGradient>
-                <linearGradient id="orangePanel" x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" stop-color="#fff0e6" />
-                  <stop offset="100%" stop-color="#fff8f2" />
-                </linearGradient>
-                <marker id="arrowInk" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-                  <path d="M0 0L10 5L0 10z" fill="#37525d" />
-                </marker>
-                <marker id="arrowAccent" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-                  <path d="M0 0L10 5L0 10z" fill="#157c68" />
-                </marker>
-                <marker id="arrowSpot" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-                  <path d="M0 0L10 5L0 10z" fill="#eb6f2f" />
-                </marker>
-              </defs>
-
-              <rect x="0" y="0" width="1140" height="620" rx="30" fill="#fffaf3" />
-
-              <text x="64" y="72" class="diagram-title">Client surfaces</text>
-              <rect x="54" y="102" width="220" height="84" rx="20" class="diagram-node diagram-node-light" />
-              <text x="80" y="136" class="diagram-node-title">Legacy GIS clients</text>
-              <text x="80" y="164" class="diagram-node-copy">ArcGIS Pro, ArcGIS JS, Esri SDK apps, QGIS</text>
-
-              <rect x="54" y="210" width="220" height="84" rx="20" class="diagram-node diagram-node-light" />
-              <text x="80" y="244" class="diagram-node-title">Data and BI tools</text>
-              <text x="80" y="272" class="diagram-node-copy">Power BI, Excel, Tableau, ERP, low-code</text>
-
-              <rect x="54" y="318" width="220" height="84" rx="20" class="diagram-node diagram-node-highlight" />
-              <text x="80" y="352" class="diagram-node-title">Modern apps and mobile</text>
-              <text x="80" y="380" class="diagram-node-copy">Web apps, services, MAUI field apps, sync workers</text>
-
-              <rect x="54" y="426" width="220" height="84" rx="20" class="diagram-node diagram-node-spot" />
-              <text x="80" y="460" class="diagram-node-title">AI agents and assistants</text>
-              <text x="80" y="488" class="diagram-node-copy">Coding agents, copilots, analyst assistants, automations</text>
-
-              <text x="344" y="72" class="diagram-title">Access rails</text>
-              <rect x="324" y="102" width="222" height="118" rx="22" class="diagram-panel diagram-panel-neutral" />
-              <text x="354" y="138" class="diagram-panel-title">Compatibility layer</text>
-              <text x="354" y="168" class="diagram-panel-copy">GeoServices REST</text>
-              <text x="354" y="193" class="diagram-panel-copy">OGC API, WMS, WMTS, OData, MVT</text>
-
-              <rect x="324" y="246" width="222" height="118" rx="22" class="diagram-panel diagram-panel-accent" />
-              <text x="354" y="282" class="diagram-panel-title">gRPC innovation rail</text>
-              <text x="354" y="312" class="diagram-panel-copy">Binary transport for app, SDK, and mobile paths</text>
-              <text x="354" y="337" class="diagram-panel-copy">Unary open surface, streaming scale path</text>
-
-              <rect x="324" y="390" width="222" height="118" rx="22" class="diagram-panel diagram-panel-spot" />
-              <text x="354" y="426" class="diagram-panel-title">MCP innovation rail</text>
-              <text x="354" y="456" class="diagram-panel-copy">Discovery, schema inspection, filtered query workflows</text>
-              <text x="354" y="481" class="diagram-panel-copy">Agent-native access to the geospatial platform</text>
-
-              <text x="622" y="72" class="diagram-title">Honua platform</text>
-              <rect x="600" y="102" width="304" height="408" rx="28" fill="url(#inkPanel)" />
-              <text x="634" y="146" class="diagram-platform-title">Honua runtime + control plane</text>
-              <text x="634" y="182" class="diagram-platform-copy">Multi-protocol server runtime</text>
-              <text x="634" y="210" class="diagram-platform-copy">Admin API and admin UI</text>
-              <text x="634" y="238" class="diagram-platform-copy">SDK compatibility contracts</text>
-              <text x="634" y="266" class="diagram-platform-copy">Migration tooling and MCP package</text>
-              <text x="634" y="294" class="diagram-platform-copy">Mobile sync, forms, and offline workflows</text>
-              <rect x="632" y="330" width="236" height="52" rx="16" class="diagram-chip diagram-chip-accent" />
-              <text x="654" y="362" class="diagram-chip-title">gRPC differentiates app and mobile performance</text>
-              <rect x="632" y="398" width="236" height="52" rx="16" class="diagram-chip diagram-chip-spot" />
-              <text x="654" y="430" class="diagram-chip-title">MCP differentiates the agent integration layer</text>
-
-              <text x="946" y="72" class="diagram-title">Backing systems</text>
-              <rect x="924" y="102" width="164" height="84" rx="20" class="diagram-node diagram-node-light" />
-              <text x="948" y="136" class="diagram-node-title">PostGIS + storage</text>
-              <text x="948" y="164" class="diagram-node-copy">Core data and persistence</text>
-
-              <rect x="924" y="210" width="164" height="84" rx="20" class="diagram-node diagram-node-light" />
-              <text x="948" y="244" class="diagram-node-title">Cloud targets</text>
-              <text x="948" y="272" class="diagram-node-copy">Docker, K8s, AWS, Azure, serverless</text>
-
-              <rect x="924" y="318" width="164" height="84" rx="20" class="diagram-node diagram-node-light" />
-              <text x="948" y="352" class="diagram-node-title">Observability</text>
-              <text x="948" y="380" class="diagram-node-copy">OpenTelemetry, metrics, health, logs</text>
-
-              <line x1="274" y1="144" x2="324" y2="144" class="diagram-line" marker-end="url(#arrowInk)" />
-              <line x1="274" y1="252" x2="324" y2="158" class="diagram-line" marker-end="url(#arrowInk)" />
-              <line x1="274" y1="360" x2="324" y2="304" class="diagram-line-accent" marker-end="url(#arrowAccent)" />
-              <line x1="274" y1="468" x2="324" y2="448" class="diagram-line-spot" marker-end="url(#arrowSpot)" />
-
-              <line x1="546" y1="160" x2="600" y2="188" class="diagram-line" marker-end="url(#arrowInk)" />
-              <line x1="546" y1="304" x2="600" y2="304" class="diagram-line-accent" marker-end="url(#arrowAccent)" />
-              <line x1="546" y1="448" x2="600" y2="420" class="diagram-line-spot" marker-end="url(#arrowSpot)" />
-
-              <line x1="904" y1="188" x2="924" y2="144" class="diagram-line" marker-end="url(#arrowInk)" />
-              <line x1="904" y1="304" x2="924" y2="252" class="diagram-line" marker-end="url(#arrowInk)" />
-              <line x1="904" y1="420" x2="924" y2="360" class="diagram-line" marker-end="url(#arrowInk)" />
-            </svg>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Team or client</th>
+                  <th>Connects through</th>
+                  <th>What it enables</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ArcGIS, QGIS, BI tools, and existing web map clients</td>
+                  <td>GeoServices REST, OGC API, OData, WMS, WMTS, and tiles</td>
+                  <td>Low-risk migration and compatibility with existing GIS and analytics workflows</td>
+                </tr>
+                <tr>
+                  <td>New applications, services, and mobile clients</td>
+                  <td>gRPC and official SDKs</td>
+                  <td>Typed access, faster app integration, and better mobile performance</td>
+                </tr>
+                <tr>
+                  <td>AI assistants, copilots, and coding agents</td>
+                  <td>MCP</td>
+                  <td>Supported discovery, schema inspection, and filtered query workflows</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
-          <div class="note-grid" style="margin-top: 18px;">
-            <article class="note-card">
-              <h3>Compatibility is the entry wedge</h3>
-              <p>GeoServices REST, OGC API, OData, WMS, WMTS, and tiles keep migration low-risk and let teams preserve existing clients.</p>
-            </article>
-            <article class="note-card">
-              <h3>gRPC and MCP are the forward wedge</h3>
-              <p>gRPC is the fast path for apps and mobile. MCP is the safe path for agents. Those two rails are what make Honua feel contemporary rather than merely compatible.</p>
-            </article>
+          <div class="callout">
+            All three paths reach the same PostGIS-backed runtime with admin APIs, official SDKs, mobile tooling, and deployment options for Docker, Kubernetes, AWS, and Azure.
           </div>
         </section>
 
@@ -269,7 +188,7 @@
             </article>
             <article class="note-card">
               <h3>No protocol or SDK add-ons</h3>
-              <p>GeoServices REST, OGC API, OData, SDKs, and the mobile story belong in the product, not behind extra fees.</p>
+              <p>GeoServices REST, OGC API, OData, SDKs, and mobile tooling are part of the product, not separate upsells.</p>
             </article>
             <article class="note-card">
               <h3>Pay for depth, not permission</h3>
@@ -284,10 +203,10 @@
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">What Ships Together</p>
-            <h2>One platform, multiple surfaces.</h2>
+            <p class="eyebrow">What You Get</p>
+            <h2>Runtime, SDKs, mobile, and operations in one platform.</h2>
             <p class="section-copy">
-              In one scan: what runs, how you integrate, how you migrate, how you deploy, and how licensing works.
+              Honua combines a geospatial runtime, official SDKs, field tooling, migration helpers, and flexible deployment options.
             </p>
           </div>
           <div class="card-grid card-grid-three">
@@ -311,20 +230,19 @@
               <p class="card-kicker">Mobile</p>
               <h3>Field workflows without vendor lock-in</h3>
               <p>
-                Mobile SDK surfaces cover offline GeoPackage sync, forms, background upload, and gRPC-first feature access.
+                Mobile tooling covers offline GeoPackage sync, forms, background upload, and gRPC-first feature access.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">AI and Agents</p>
-              <h3>MCP as a first-class surface</h3>
+              <h3>MCP for agents</h3>
               <p>
-                MCP is a first-class part of the platform story for discovery, schema inspection, query workflows, and
-                agent integration.
+                MCP adds discovery, schema inspection, query workflows, and agent integration without requiring custom scraping or glue code.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Migration</p>
-              <h3>Esri and GeoServer replacement lane</h3>
+              <h3>Replace ArcGIS and GeoServer with less risk</h3>
               <p>
                 Compatibility, standards, pricing clarity, and staged adoption keep replacement projects credible.
               </p>
@@ -343,10 +261,9 @@
           <div class="detail-grid">
             <article class="detail-card">
               <p class="eyebrow">Proof</p>
-              <h2>Compatibility and conformance have dedicated room.</h2>
+              <h2>Verified compatibility and standards support.</h2>
               <p>
-                Honua already carries launch-facing compatibility and conformance evidence across OGC API, WMS, WMTS,
-                GeoServices-style surfaces, and SDK compatibility guidance. That proof is part of the product story, not an appendix.
+                Honua publishes compatibility and conformance evidence across OGC API, WMS, WMTS, GeoServices-style APIs, and SDK compatibility guidance.
               </p>
               <a class="text-link" href="protocols.html">Explore protocol coverage</a>
             </article>
@@ -365,27 +282,27 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Choose a Path</p>
-            <h2>Start from the surface that matches your team.</h2>
+            <h2>Start with the page that matches your role.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card card-link">
               <h3>Platform</h3>
-              <p>See the full runtime, control plane direction, deployment targets, and migration posture.</p>
+              <p>See the runtime, admin APIs, deployment targets, and migration approach.</p>
               <a class="text-link" href="platform.html">Go to Platform</a>
             </article>
             <article class="card card-link">
               <h3>Protocols</h3>
-              <p>Understand where GeoServices REST, OGC API, OData, gRPC, MCP, and tiles fit together.</p>
+              <p>See the APIs and formats Honua supports for GIS clients, analytics, applications, and agents.</p>
               <a class="text-link" href="protocols.html">Go to Protocols</a>
             </article>
             <article class="card card-link">
               <h3>SDKs</h3>
-              <p>Pick a client surface for JavaScript, .NET, Python, migration tooling, or agent workflows.</p>
+              <p>Choose JavaScript, .NET, Python, or MCP based on how your team builds and integrates.</p>
               <a class="text-link" href="sdks.html">Go to SDKs</a>
             </article>
             <article class="card card-link">
               <h3>Mobile</h3>
-              <p>See the MAUI-first field collection and offline sync story without per-user licensing.</p>
+              <p>See MAUI-first field collection, offline sync, and mobile tooling without per-user licensing.</p>
               <a class="text-link" href="mobile.html">Go to Mobile</a>
             </article>
             <article class="card card-link">
@@ -405,9 +322,9 @@
           <div class="contact-grid">
             <div class="contact-copy">
               <p class="eyebrow">Early Access</p>
-              <h2>Planning a migration, launch, or field workflow rollout?</h2>
+              <h2>Planning a migration, rollout, or field app?</h2>
               <p>
-                Tell us what you are replacing, what client surfaces matter, and whether the pressure is standards,
+                Tell us which system you are replacing, which clients matter, and whether the pressure is standards,
                 licensing, mobile, SDK adoption, or platform consolidation.
               </p>
               <div class="contact-points">
@@ -437,7 +354,7 @@
                 <textarea
                   name="message"
                   rows="6"
-                  placeholder="Examples: GeoServer migration, ArcGIS cost pressure, mobile field workflow, MCP access for agents, SDK rollout, launch docs."
+                  placeholder="Examples: GeoServer migration, ArcGIS cost pressure, field data collection, MCP access for agents, SDK adoption."
                   required
                 ></textarea>
               </label>

--- a/mobile.html
+++ b/mobile.html
@@ -6,7 +6,7 @@
     <title>Honua Mobile | MAUI, Offline GeoPackage Sync, gRPC Field Workflows</title>
     <meta
       name="description"
-      content="Honua Mobile brings MAUI-first field workflows, GeoPackage offline storage, forms, background sync, and gRPC-first access into the platform story."
+      content="Honua Mobile brings MAUI-first field workflows, GeoPackage offline storage, forms, background sync, and gRPC-first access into the platform."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -36,17 +36,16 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Mobile</p>
-          <h1>Field workflows are part of the platform.</h1>
+          <h1>Build field workflows on the same Honua platform.</h1>
           <p class="page-intro">
-            Honua includes a MAUI-first mobile lane with offline GeoPackage sync, forms, background upload, and
-            gRPC-first performance for operational teams.
+            Honua includes .NET MAUI mobile tooling for offline maps, forms, sync, background upload, and fast feature access.
           </p>
         </section>
 
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Mobile Positioning</p>
-            <h2>What the mobile surface includes.</h2>
+            <h2>Core mobile capabilities.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
@@ -62,17 +61,17 @@
             <article class="card">
               <p class="card-kicker">Framework</p>
               <h3>MAUI-first cross-platform</h3>
-              <p>The current mobile lane is rooted in .NET MAUI with iOS, Android, and Windows support, which makes it legible to enterprise app teams.</p>
+              <p>The mobile stack is built on .NET MAUI with iOS, Android, and Windows support for teams already working in Microsoft-heavy environments.</p>
             </article>
             <article class="card">
               <p class="card-kicker">Field UX</p>
               <h3>Forms and record workflows</h3>
-              <p>Dynamic form schema, validation, calculated fields, duplicate detection, and record lifecycle support define the field workflow story.</p>
+              <p>Dynamic forms, validation, calculated fields, duplicate detection, and record lifecycle tools support real field operations.</p>
             </article>
             <article class="card">
               <p class="card-kicker">Sync</p>
               <h3>Background upload and conflict handling</h3>
-              <p>Connectivity-aware background sync and conflict strategies turn mobile from a demo into an operational lane.</p>
+              <p>Connectivity-aware background sync and conflict strategies make the mobile client usable in day-to-day operations.</p>
             </article>
             <article class="card">
               <p class="card-kicker">Economics</p>
@@ -84,22 +83,22 @@
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Mobile Stack</p>
-            <h2>What ships in the current mobile surface.</h2>
+            <p class="eyebrow">Components</p>
+            <h2>Core mobile components.</h2>
           </div>
           <div class="table-wrap">
             <table>
               <thead>
                 <tr>
-                  <th>Package / layer</th>
+                  <th>Component</th>
                   <th>Purpose</th>
-                  <th>Public message</th>
+                  <th>Why it matters</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
                   <td>Honua.Mobile.Sdk</td>
-                  <td>Transport, auth, and mobile client surface</td>
+                  <td>Transport, auth, and mobile client library</td>
                   <td>Use Honua APIs from MAUI apps without standing up a separate mobile backend product.</td>
                 </tr>
                 <tr>
@@ -115,7 +114,7 @@
                 <tr>
                   <td>Honua.Mobile.Maui</td>
                   <td>MAUI service registration and UI integration</td>
-                  <td>Show that mobile development is part of the same developer story as the server and SDKs.</td>
+                  <td>Mobile development uses the same platform foundation as the server and SDKs.</td>
                 </tr>
               </tbody>
             </table>
@@ -126,16 +125,16 @@
           <div class="detail-grid">
             <article class="detail-card">
               <p class="eyebrow">Positioning</p>
-              <h2>Mobile changes the category.</h2>
+              <h2>Mobile extends Honua beyond the server.</h2>
               <p>
-                Once mobile is real, Honua stops reading as only a server replacement and starts reading as a platform for collection, sync, data access, and delivery.
+                With mobile tooling in place, Honua covers collection, sync, data access, and delivery instead of stopping at server replacement.
               </p>
             </article>
             <article class="detail-card">
               <p class="eyebrow">Pricing</p>
-              <h2>Licensing becomes part of the field story.</h2>
+              <h2>No separate field-user tax.</h2>
               <p>
-                Field buyers are sensitive to per-user mobile pricing. Honua ties mobile capabilities to the same no-per-user posture as the rest of the platform.
+                Field teams do not need a separate per-user mobile subscription. Mobile capabilities follow the same no-seat posture as the rest of the platform.
               </p>
             </article>
           </div>
@@ -143,9 +142,9 @@
 
         <section class="cta-band">
           <p class="eyebrow">Next</p>
-          <h2>Mobile only works if the pricing and docs story are equally clear.</h2>
+          <h2>Need pricing or a quickstart next?</h2>
           <p>
-            After a visitor understands the mobile lane, the next questions are almost always licensing, procurement, and how fast they can try it.
+            After the mobile overview, most teams want pricing details and a quick way to try the platform.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="pricing.html">View Pricing</a>

--- a/platform.html
+++ b/platform.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Honua Platform | Runtime, Control Plane, SDKs, and Deployment</title>
+    <title>Honua Platform | Runtime, Admin APIs, SDKs, and Deployment</title>
     <meta
       name="description"
-      content="See the Honua platform shape: multi-protocol server runtime, admin and control plane direction, SDKs, mobile, MCP, migration posture, and cloud-native deployment targets."
+      content="See the Honua platform: multi-protocol server runtime, admin APIs, SDKs, mobile, MCP, migration tooling, and cloud deployment targets."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -38,17 +38,17 @@
           <p class="eyebrow">Platform</p>
           <h1>Honua is a platform, not just a server.</h1>
           <p class="page-intro">
-            Honua combines a multi-protocol server runtime, typed SDKs, mobile field foundations, MCP tooling,
-            migration helpers, and cloud-native deployment options in one coherent system.
+            Honua combines a multi-protocol geospatial runtime, admin APIs, official SDKs, mobile tooling, MCP access,
+            migration helpers, and cloud deployment options in one platform.
           </p>
         </section>
 
         <section class="section section-contrast">
           <div class="section-heading">
             <p class="eyebrow">Differentiation</p>
-            <h2>Compatibility gets attention. gRPC and MCP create the forward edge.</h2>
+            <h2>Built for compatibility and modern delivery.</h2>
             <p class="section-copy">
-              GeoServices REST and OGC compatibility win trust during migration, while gRPC and MCP are the modern rails that make Honua feel like a next-generation platform.
+              GeoServices REST and OGC compatibility let teams migrate without breaking clients. gRPC and MCP give new applications, mobile clients, and agents a better interface than legacy GIS stacks.
             </p>
           </div>
           <div class="detail-grid">
@@ -63,7 +63,7 @@
               <p class="eyebrow">MCP</p>
               <h2>Agent path into the platform</h2>
               <p>
-                `MCP` is what makes Honua legible to AI assistants and coding agents. That matters enough to be visible at the platform layer, not only in a niche docs page.
+                MCP gives AI assistants and coding agents a supported path for discovery, schema inspection, and query workflows.
               </p>
             </article>
           </div>
@@ -84,16 +84,16 @@
             </article>
             <article class="card">
               <p class="card-kicker">Admin</p>
-              <h3>Control plane direction</h3>
+              <h3>Admin APIs and UI</h3>
               <p>
-                Admin APIs and the admin UI are the foundation for publishing, governance, deployment coordination, and future control-plane workflows.
+                Admin APIs and the admin UI handle publishing, governance, and deployment coordination.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Integrations</p>
               <h3>SDKs and agents</h3>
               <p>
-                JavaScript, .NET, Python, migration utilities, and the MCP server keep evaluation friction low and make the platform legible to developers.
+                JavaScript, .NET, Python, migration utilities, and the MCP package give developers a faster path from evaluation to production.
               </p>
             </article>
             <article class="card">
@@ -105,9 +105,9 @@
             </article>
             <article class="card">
               <p class="card-kicker">Migration</p>
-              <h3>Replacement wedge</h3>
+              <h3>Migration path</h3>
               <p>
-                ArcGIS and GeoServer displacement remain the sharpest story: compatibility, staged migration, standards, and pricing clarity.
+                ArcGIS and GeoServer replacement stays practical through compatibility, staged migration, standards support, and predictable licensing.
               </p>
             </article>
             <article class="card">
@@ -122,16 +122,16 @@
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Surface Map</p>
-            <h2>How the product surfaces fit together.</h2>
+            <p class="eyebrow">Product Areas</p>
+            <h2>How the main product areas fit together.</h2>
           </div>
           <div class="table-wrap">
             <table>
               <thead>
                 <tr>
-                  <th>Surface</th>
-                  <th>Role in the platform</th>
-                  <th>What the product emphasizes</th>
+                  <th>Area</th>
+                  <th>What it includes</th>
+                  <th>Why it matters</th>
                 </tr>
               </thead>
               <tbody>
@@ -141,13 +141,13 @@
                   <td>Compatibility, conformance, standards, operational footprint, and licensing model</td>
                 </tr>
                 <tr>
-                  <td>Admin and Control Plane</td>
+                  <td>Admin APIs and UI</td>
                   <td>Publishing, governance, environment management, rollout direction</td>
-                  <td>Operational confidence and future control-plane credibility</td>
+                  <td>Operational confidence, governance, and deployment coordination</td>
                 </tr>
                 <tr>
                   <td>SDKs</td>
-                  <td>Developer adoption surface across JavaScript, .NET, and Python</td>
+                  <td>Official libraries for JavaScript, .NET, and Python</td>
                   <td>Typed clients, quickstarts, migration tooling, and compatibility contracts</td>
                 </tr>
                 <tr>
@@ -157,8 +157,8 @@
                 </tr>
                 <tr>
                   <td>MCP</td>
-                  <td>Agent and AI integration surface</td>
-                  <td>Discovery, schema inspection, filtered query workflows, and secure tool surfaces</td>
+                  <td>Agent and AI integration access</td>
+                  <td>Discovery, schema inspection, filtered query workflows, and secure tool access</td>
                 </tr>
                 <tr>
                   <td>Private operator layer</td>
@@ -167,7 +167,7 @@
                 </tr>
                 <tr>
                   <td>Pricing and Editions</td>
-                  <td>Trust and procurement narrative</td>
+                  <td>Pricing, licensing, and edition model</td>
                   <td>No per-user fees, no protocol gating, open-core boundary, and clear edition differences</td>
                 </tr>
               </tbody>
@@ -178,15 +178,15 @@
         <section class="section section-contrast">
           <div class="note-grid">
             <article class="note-card">
-              <h3>Why this is broader than a server</h3>
+              <h3>Why teams buy a platform, not a point product</h3>
               <p>
-                MCP, mobile, gRPC, SDK breadth, licensing nuance, and the control-plane arc make Honua read as a platform, not a single runtime.
+                Honua combines compatibility, SDKs, mobile tooling, modern APIs, and operations so teams do not have to assemble those pieces themselves.
               </p>
             </article>
             <article class="note-card">
-              <h3>What ties it together</h3>
+              <h3>How the pieces work together</h3>
               <p>
-                The platform spans protocol surface, developer surface, mobile surface, procurement surface, migration surface, and a clearly separated private operator layer.
+                The runtime, admin APIs, SDKs, mobile tooling, pricing model, and private operator layer all build on the same platform foundation.
               </p>
             </article>
           </div>
@@ -194,7 +194,7 @@
 
         <section class="cta-band">
           <p class="eyebrow">Next</p>
-          <h2>Drill into the exact surfaces your team needs.</h2>
+          <h2>Explore the parts of the platform your team needs.</h2>
           <p>
             Protocols explain interoperability. SDKs explain adoption. Mobile explains field workflows. Pricing explains whether the platform is actually practical to buy and deploy.
           </p>

--- a/pricing.html
+++ b/pricing.html
@@ -50,7 +50,7 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Buyer Snapshot</p>
-            <h2>The model is legible in one scan.</h2>
+            <h2>Pricing is simple to explain.</h2>
           </div>
           <div class="mini-grid">
             <article class="note-card">
@@ -63,7 +63,7 @@
             </article>
             <article class="note-card">
               <h3>No SDK surcharge</h3>
-              <p>JavaScript, .NET, Python, mobile tooling, and MCP belong in the platform story without extra client-side licensing friction.</p>
+              <p>JavaScript, .NET, Python, mobile tooling, and MCP are included without extra client-side licensing friction.</p>
             </article>
             <article class="note-card">
               <h3>Pay for production depth</h3>
@@ -87,8 +87,8 @@
               <p>GeoServices REST, OGC API, OData, tiles, and SDK access stay visible because they are part of adoption, not premium upsell bait.</p>
             </article>
             <article class="note-card">
-              <h3>SDKs and client surfaces</h3>
-              <p>The product story stays cleaner when developer surfaces, mobile tooling, and client access are not split into optional taxes.</p>
+              <h3>SDKs and clients</h3>
+              <p>Developer libraries, mobile tooling, and client access are included instead of split into optional taxes.</p>
             </article>
             <article class="note-card">
               <h3>What commercial tiers actually cover</h3>
@@ -100,21 +100,21 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Private Operator Layer</p>
-            <h2>One surface is intentionally not open-core.</h2>
+            <h2>The AI operator tool is separate by design.</h2>
           </div>
           <div class="detail-grid">
             <article class="detail-card">
               <p class="eyebrow">Public</p>
               <h2>Runtime, protocols, SDKs, mobile, and base MCP</h2>
               <p>
-                The open-core promise covers the server runtime, protocol surfaces, official SDKs, mobile tooling, and the base MCP data-access layer.
+                The open-core promise covers the server runtime, protocol APIs, official SDKs, mobile tooling, and the base MCP data-access layer.
               </p>
             </article>
             <article class="detail-card">
               <p class="eyebrow">Private</p>
               <h2>AI DevOps/operator copilot</h2>
               <p>
-                Operator-grade rollout planning, delegated operations, and implementation-partner workflows can remain private enterprise tooling on top of the public control-plane API.
+                Operator-grade rollout planning, delegated operations, and implementation-partner workflows can remain private enterprise tooling on top of the public admin APIs.
               </p>
             </article>
           </div>
@@ -133,7 +133,7 @@
               <p class="eyebrow">What You Do Pay For</p>
               <h2>Coordinated scale, governance, and enterprise confidence.</h2>
               <p>
-                The paid story is stronger when it is framed around distributed cache, streaming depth, support, governance, compliance, and change management instead of artificial product crippling.
+                Paid editions focus on distributed cache, streaming depth, support, governance, compliance, and change management instead of artificial product crippling.
               </p>
             </article>
           </div>
@@ -163,7 +163,7 @@
                 </tr>
                 <tr>
                   <td>Protocols and SDK access</td>
-                  <td>Core protocol and SDK surface stays visible</td>
+                  <td>Core protocols and SDKs stay available</td>
                   <td>Same protocol family with stronger runtime depth</td>
                   <td>Same protocol family with governance and compliance controls</td>
                 </tr>
@@ -187,7 +187,7 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">License Split</p>
-            <h2>Different repos have different license jobs.</h2>
+            <h2>Different parts of Honua use different licenses.</h2>
           </div>
           <div class="table-wrap">
             <table>
@@ -212,12 +212,12 @@
                 <tr>
                   <td>Mobile tooling and examples</td>
                   <td>Apache 2.0</td>
-                  <td>Field teams and integrators can evaluate the mobile surface without separate client-side licensing questions.</td>
+                  <td>Field teams and integrators can evaluate the mobile tooling without separate client-side licensing questions.</td>
                 </tr>
                 <tr>
                   <td>Site and collateral</td>
                   <td>Apache 2.0</td>
-                  <td>The public trust layer is transparent and easy to reuse internally.</td>
+                  <td>Commercial, technical, and legal teams can reuse the public collateral internally without ambiguity.</td>
                 </tr>
               </tbody>
             </table>
@@ -241,7 +241,7 @@
               <p class="eyebrow">Trust</p>
               <h2>Licensing is part of trust, not fine print.</h2>
               <p>
-                If the public story is unclear about license boundaries, procurement and legal will assume the worst. This page removes that ambiguity.
+                If license boundaries are unclear, procurement and legal will assume the worst. This page removes that ambiguity.
               </p>
             </article>
           </div>

--- a/protocols.html
+++ b/protocols.html
@@ -6,7 +6,7 @@
     <title>Honua Protocols | GeoServices REST, OGC API, OData, gRPC, MCP</title>
     <meta
       name="description"
-      content="Understand the Honua protocol surface: GeoServices REST, OGC API, OData v4, gRPC, MCP, vector tiles, WMS, and WMTS."
+      content="Understand the Honua APIs and protocols: GeoServices REST, OGC API, OData v4, gRPC, MCP, vector tiles, WMS, and WMTS."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -36,36 +36,36 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Protocols</p>
-          <h1>Compatibility gets teams in. gRPC and MCP show what is actually new.</h1>
+          <h1>APIs and protocols for GIS clients, applications, analytics, and agents.</h1>
           <p class="page-intro">
             Honua brings GeoServices REST, OGC API, OData, gRPC, MCP, and cloud-native tiles together in one runtime.
-            Compatibility explains migration. gRPC and MCP explain why the platform is modern.
+            Existing GIS clients can keep working while new applications, mobile clients, and AI agents use newer access patterns.
           </p>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Innovation Layer</p>
-            <h2>The real protocol differentiation is here.</h2>
+            <p class="eyebrow">Modern APIs</p>
+            <h2>New application and agent access.</h2>
           </div>
           <div class="detail-grid">
             <article class="detail-card detail-card-accent">
               <p class="eyebrow">gRPC</p>
               <h2>Application and mobile performance rail</h2>
               <p>
-                `gRPC` is not just another protocol checkbox. It is the binary transport that makes app integrations, MAUI field workflows, and high-throughput client paths feel substantially different from pure REST-era GIS stacks.
+                gRPC gives applications and mobile clients a fast typed path for high-throughput requests, service-to-service calls, and richer field workflows.
               </p>
               <ul class="bullet-list">
                 <li>Strong fit for typed SDKs and mobile field clients.</li>
-                <li>Unary support belongs in the open protocol story.</li>
-                <li>Streaming is the commercial scale path, not the compatibility wedge.</li>
+                <li>Unary access is available in the base platform.</li>
+                <li>Streaming is the commercial path for larger workloads.</li>
               </ul>
             </article>
             <article class="detail-card detail-card-spot">
               <p class="eyebrow">MCP</p>
               <h2>Agent-native geospatial access rail</h2>
               <p>
-                `MCP` is the surface that makes Honua legible to coding agents, copilots, and analyst assistants. It turns service discovery, schema inspection, and filtered queries into tool-safe workflows instead of ad hoc scraping.
+                MCP lets coding agents, copilots, and analyst assistants discover services, inspect schemas, and run filtered queries through a supported interface.
               </p>
               <ul class="bullet-list">
                 <li>Discovery and query workflows for AI assistants.</li>
@@ -78,110 +78,54 @@
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Protocol Diagram</p>
-            <h2>How the protocol layers actually fit together.</h2>
+            <p class="eyebrow">Connection Model</p>
+            <h2>Which access path fits which client.</h2>
             <p class="section-copy">
-              This visual separates migration compatibility from forward-looking integration rails. It shows why gRPC and MCP matter without discarding the compatibility story.
+              Honua supports old and new access patterns at the same time. Use the path that matches the client you already have or the application you want to build.
             </p>
           </div>
-          <div class="diagram-shell">
-            <svg class="platform-diagram" viewBox="0 0 1140 620" role="img" aria-label="Protocol diagram showing clients entering through compatibility, gRPC, and MCP rails into the Honua runtime">
-              <defs>
-                <linearGradient id="protoInk" x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" stop-color="#14252c" />
-                  <stop offset="100%" stop-color="#203b44" />
-                </linearGradient>
-                <marker id="protoArrowInk" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-                  <path d="M0 0L10 5L0 10z" fill="#37525d" />
-                </marker>
-                <marker id="protoArrowAccent" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-                  <path d="M0 0L10 5L0 10z" fill="#157c68" />
-                </marker>
-                <marker id="protoArrowSpot" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-                  <path d="M0 0L10 5L0 10z" fill="#eb6f2f" />
-                </marker>
-              </defs>
-
-              <rect x="0" y="0" width="1140" height="620" rx="30" fill="#fffaf3" />
-              <text x="74" y="76" class="diagram-title">Client classes</text>
-              <rect x="60" y="112" width="226" height="84" rx="20" class="diagram-node diagram-node-light" />
-              <text x="86" y="146" class="diagram-node-title">Existing GIS clients</text>
-              <text x="86" y="174" class="diagram-node-copy">ArcGIS, QGIS, web map clients</text>
-
-              <rect x="60" y="224" width="226" height="84" rx="20" class="diagram-node diagram-node-light" />
-              <text x="86" y="258" class="diagram-node-title">Business and data tools</text>
-              <text x="86" y="286" class="diagram-node-copy">BI, analytics, enterprise data apps</text>
-
-              <rect x="60" y="336" width="226" height="84" rx="20" class="diagram-node diagram-node-highlight" />
-              <text x="86" y="370" class="diagram-node-title">SDK apps and mobile</text>
-              <text x="86" y="398" class="diagram-node-copy">Typed clients, services, MAUI field apps</text>
-
-              <rect x="60" y="448" width="226" height="84" rx="20" class="diagram-node diagram-node-spot" />
-              <text x="86" y="482" class="diagram-node-title">Agents and copilots</text>
-              <text x="86" y="510" class="diagram-node-copy">Discovery, schema, query workflows</text>
-
-              <text x="348" y="76" class="diagram-title">Protocol rails</text>
-              <rect x="330" y="112" width="244" height="120" rx="22" class="diagram-panel diagram-panel-neutral" />
-              <text x="360" y="148" class="diagram-panel-title">Compatibility rail</text>
-              <text x="360" y="178" class="diagram-panel-copy">GeoServices REST, OGC API, OData, tiles</text>
-              <text x="360" y="203" class="diagram-panel-copy">Migration continuity and open standards</text>
-
-              <rect x="330" y="256" width="244" height="120" rx="22" class="diagram-panel diagram-panel-accent" />
-              <text x="360" y="292" class="diagram-panel-title">gRPC rail</text>
-              <text x="360" y="322" class="diagram-panel-copy">High-throughput binary path for SDKs and mobile</text>
-              <text x="360" y="347" class="diagram-panel-copy">Unary open, streaming scale path</text>
-
-              <rect x="330" y="400" width="244" height="120" rx="22" class="diagram-panel diagram-panel-spot" />
-              <text x="360" y="436" class="diagram-panel-title">MCP rail</text>
-              <text x="360" y="466" class="diagram-panel-copy">Agent-safe discovery, schema, and query access</text>
-              <text x="360" y="491" class="diagram-panel-copy">Modern AI integration path</text>
-
-              <text x="650" y="76" class="diagram-title">Honua runtime</text>
-              <rect x="628" y="112" width="298" height="408" rx="28" fill="url(#protoInk)" />
-              <text x="662" y="152" class="diagram-platform-title">Unified geospatial platform</text>
-              <text x="662" y="190" class="diagram-platform-copy">Server runtime</text>
-              <text x="662" y="218" class="diagram-platform-copy">Admin API and admin UI</text>
-              <text x="662" y="246" class="diagram-platform-copy">SDKs and migration tooling</text>
-              <text x="662" y="274" class="diagram-platform-copy">Mobile sync and field workflows</text>
-              <text x="662" y="302" class="diagram-platform-copy">MCP package and agent access</text>
-              <rect x="660" y="338" width="234" height="56" rx="16" class="diagram-chip diagram-chip-accent" />
-              <text x="682" y="372" class="diagram-chip-title">gRPC = app and mobile acceleration</text>
-              <rect x="660" y="410" width="234" height="56" rx="16" class="diagram-chip diagram-chip-spot" />
-              <text x="682" y="444" class="diagram-chip-title">MCP = AI and agent integration</text>
-
-              <text x="970" y="76" class="diagram-title">Outcomes</text>
-              <rect x="946" y="140" width="150" height="84" rx="20" class="diagram-node diagram-node-light" />
-              <text x="970" y="174" class="diagram-node-title">Migration</text>
-              <text x="970" y="202" class="diagram-node-copy">Low-risk replacement path</text>
-
-              <rect x="946" y="266" width="150" height="84" rx="20" class="diagram-node diagram-node-highlight" />
-              <text x="970" y="300" class="diagram-node-title">Apps + mobile</text>
-              <text x="970" y="328" class="diagram-node-copy">Faster, typed, operational clients</text>
-
-              <rect x="946" y="392" width="150" height="84" rx="20" class="diagram-node diagram-node-spot" />
-              <text x="970" y="426" class="diagram-node-title">Agents</text>
-              <text x="970" y="454" class="diagram-node-copy">Tool-safe AI access</text>
-
-              <line x1="286" y1="154" x2="330" y2="154" class="diagram-line" marker-end="url(#protoArrowInk)" />
-              <line x1="286" y1="266" x2="330" y2="190" class="diagram-line" marker-end="url(#protoArrowInk)" />
-              <line x1="286" y1="378" x2="330" y2="316" class="diagram-line-accent" marker-end="url(#protoArrowAccent)" />
-              <line x1="286" y1="490" x2="330" y2="460" class="diagram-line-spot" marker-end="url(#protoArrowSpot)" />
-
-              <line x1="574" y1="172" x2="628" y2="206" class="diagram-line" marker-end="url(#protoArrowInk)" />
-              <line x1="574" y1="316" x2="628" y2="316" class="diagram-line-accent" marker-end="url(#protoArrowAccent)" />
-              <line x1="574" y1="460" x2="628" y2="438" class="diagram-line-spot" marker-end="url(#protoArrowSpot)" />
-
-              <line x1="926" y1="206" x2="946" y2="182" class="diagram-line" marker-end="url(#protoArrowInk)" />
-              <line x1="926" y1="316" x2="946" y2="308" class="diagram-line-accent" marker-end="url(#protoArrowAccent)" />
-              <line x1="926" y1="438" x2="946" y2="434" class="diagram-line-spot" marker-end="url(#protoArrowSpot)" />
-            </svg>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Client type</th>
+                  <th>Primary access path</th>
+                  <th>Typical use</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>ArcGIS, QGIS, web map clients, and existing GIS tooling</td>
+                  <td>GeoServices REST, OGC API, WMS, WMTS, and tiles</td>
+                  <td>Migration, compatibility, and standards-based access</td>
+                </tr>
+                <tr>
+                  <td>Excel, Power BI, Tableau, ERP, and low-code tools</td>
+                  <td>OData v4</td>
+                  <td>Business analytics and spatial data access outside traditional GIS tools</td>
+                </tr>
+                <tr>
+                  <td>Application backends, services, and mobile clients</td>
+                  <td>gRPC</td>
+                  <td>Typed access, higher throughput, and better application and mobile performance</td>
+                </tr>
+                <tr>
+                  <td>AI assistants, copilots, and coding agents</td>
+                  <td>MCP</td>
+                  <td>Discovery, schema inspection, and filtered query workflows through a supported interface</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="callout">
+            One Honua deployment can support these access patterns at the same time, so teams do not need separate products for migration, analytics, mobile, and agent workflows.
           </div>
         </section>
 
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Coverage</p>
-            <h2>The headline protocol set.</h2>
+            <h2>Supported APIs and formats.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
@@ -197,12 +141,12 @@
             <article class="card">
               <p class="card-kicker">OData v4</p>
               <h3>Spatial data in business systems</h3>
-              <p>Excel, Power BI, Tableau, ERP, and low-code systems become part of the platform story instead of side integrations.</p>
+              <p>Excel, Power BI, Tableau, ERP, and low-code systems can use the same geospatial data without custom side integrations.</p>
             </article>
             <article class="card">
               <p class="card-kicker">gRPC</p>
               <h3>Binary transport for high-throughput paths</h3>
-              <p>gRPC is the modern app and mobile rail. Unary support is part of the open surface. Streaming is the scale and performance unlock that differentiates paid runtime tiers.</p>
+              <p>gRPC is the app and mobile path. Unary support is part of the base platform. Streaming unlocks higher throughput in paid runtime tiers.</p>
             </article>
             <article class="card">
               <p class="card-kicker">MCP</p>
@@ -220,13 +164,13 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Edition Boundary</p>
-            <h2>Do not gate protocols. Gate runtime capability.</h2>
+            <h2>Every edition keeps the same protocol family.</h2>
           </div>
           <div class="table-wrap">
             <table>
               <thead>
                 <tr>
-                  <th>Surface</th>
+                  <th>Capability</th>
                   <th>Community</th>
                   <th>Pro / Enterprise expansion</th>
                 </tr>
@@ -234,12 +178,12 @@
               <tbody>
                 <tr>
                   <td>GeoServices REST, OGC API, OData, tiles, WMS, WMTS</td>
-                  <td>Available in the base server surface</td>
+                  <td>Available in the base server</td>
                   <td>Same protocol family, with stronger scale and governance around it</td>
                 </tr>
                 <tr>
                   <td>gRPC</td>
-                  <td>Unary gRPC support is part of the open protocol surface</td>
+                  <td>Unary gRPC support is part of the base platform</td>
                   <td>Streaming unlocks the high-throughput binary path for larger workloads</td>
                 </tr>
                 <tr>
@@ -256,8 +200,7 @@
             </table>
           </div>
           <div class="callout">
-            The public pricing story reinforces the protocol rule: buyers are paying for runtime coordination,
-            streaming depth, governance, and support, not for permission to speak a protocol.
+            Paid editions expand scale, governance, and operational depth. They do not remove API access from the base platform.
           </div>
         </section>
 
@@ -265,17 +208,16 @@
           <div class="detail-grid">
             <article class="detail-card">
               <p class="eyebrow">Proof</p>
-              <h2>Conformance is visible.</h2>
+              <h2>Verified standards support.</h2>
               <p>
-                The launch compatibility contract already carries concrete OGC API, WMS, and WMTS coverage evidence.
-                That proof lives near the protocol story instead of disappearing into deep docs.
+                Honua already publishes concrete OGC API, WMS, and WMTS compatibility evidence so teams can evaluate standards support before they commit.
               </p>
             </article>
             <article class="detail-card">
               <p class="eyebrow">Migration</p>
               <h2>Protocol coexistence is what makes migration practical.</h2>
               <p>
-                Teams can keep ArcGIS-style clients alive while moving toward OGC, OData, `gRPC`, or `MCP`-driven workflows over time. That coexistence is the bridge from compatibility into actual platform differentiation.
+                Teams can keep ArcGIS-style clients alive while moving toward OGC, OData, gRPC, or MCP-driven workflows over time.
               </p>
             </article>
           </div>
@@ -283,7 +225,7 @@
 
         <section class="cta-band">
           <p class="eyebrow">Build On Top</p>
-          <h2>Pick the client surface that matches your protocol mix.</h2>
+          <h2>Pick the client path that matches your stack.</h2>
           <p>
             The next thing most teams need after protocol clarity is a typed entry point: JavaScript for apps, .NET for enterprise and MAUI, Python for data workflows, and MCP for agent workflows.
           </p>

--- a/sdks.html
+++ b/sdks.html
@@ -6,7 +6,7 @@
     <title>Honua SDKs | JavaScript, .NET, Python, Migration, MCP</title>
     <meta
       name="description"
-      content="Explore the Honua developer surface: JavaScript, .NET, Python, migration tooling, and MCP workflows."
+      content="Explore the Honua developer platform: JavaScript, .NET, Python, migration tooling, and MCP workflows."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -45,18 +45,18 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Primary SDKs</p>
-            <h2>Three official SDK lanes, each with a different adoption job.</h2>
+            <h2>Choose the SDK that matches how your team builds.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
               <p class="card-kicker">JavaScript</p>
-              <h3>Apps, migration, compat layers</h3>
-              <p>The JavaScript SDK covers Honua-first clients, OGC usage, Esri compatibility helpers, migration scanning, and runtime parity matrices.</p>
+              <h3>Web apps and migrations</h3>
+              <p>The JavaScript SDK covers typed clients, OGC usage, Esri compatibility helpers, migration scanning, and runtime parity matrices.</p>
               <pre><code>npm install @honua/sdk-js</code></pre>
             </article>
             <article class="card">
               <p class="card-kicker">.NET</p>
-              <h3>Enterprise, admin, and MAUI adjacency</h3>
+              <h3>Enterprise services and MAUI apps</h3>
               <p>The .NET SDK focuses on gRPC queries, admin workflows, and geocoding, with a natural path into MAUI and broader Microsoft stacks.</p>
               <pre><code>dotnet add package Honua.Sdk.Grpc --prerelease
 dotnet add package Honua.Sdk.Admin --prerelease</code></pre>
@@ -74,31 +74,31 @@ pip install honua-sdk[grpc]</code></pre>
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Beyond Basic SDKs</p>
-            <h2>The developer surface is broader than package installs.</h2>
+            <h2>More than client libraries.</h2>
           </div>
           <div class="mini-grid">
             <article class="note-card">
               <h3>Migration toolkit</h3>
               <p>
-                The JS lane includes scanners, codemods, compat wrappers, and reconciliation helpers for organizations replacing ArcGIS-centric applications.
+                The JavaScript SDK includes scanners, codemods, compat wrappers, and reconciliation helpers for organizations replacing ArcGIS-centric applications.
               </p>
             </article>
             <article class="note-card">
               <h3>MCP server package</h3>
               <p>
-                MCP needs to sit beside the SDK story because agents are now another client class. It is not just a hidden bullet in a docs appendix.
+                Use Honua with AI assistants and coding agents through a dedicated MCP package for discovery and query workflows.
               </p>
             </article>
             <article class="note-card">
               <h3>Versioning and compatibility</h3>
               <p>
-                Server and SDK compatibility contracts are part of the product trust layer. This site shows those expectations directly.
+                Server and SDK versions publish compatibility expectations so teams know what can upgrade together.
               </p>
             </article>
             <article class="note-card">
               <h3>Quickstarts</h3>
               <p>
-                The docs surface lets a team install one SDK, make one authenticated call, and understand where to go next without hunting across repos.
+                Quickstarts let a team install one SDK, make one authenticated call, and understand where to go next without hunting across repos.
               </p>
             </article>
           </div>
@@ -107,7 +107,7 @@ pip install honua-sdk[grpc]</code></pre>
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">How To Choose</p>
-            <h2>Match the SDK to the adoption motion.</h2>
+            <h2>Choose the right SDK for your team.</h2>
           </div>
           <div class="table-wrap">
             <table>
@@ -146,9 +146,9 @@ pip install honua-sdk[grpc]</code></pre>
 
         <section class="cta-band">
           <p class="eyebrow">Field Workflows</p>
-          <h2>Mobile is a first-class continuation of the SDK story.</h2>
+          <h2>Need offline sync or field apps next?</h2>
           <p>
-            Field collection, offline sync, and MAUI-first mobile experiences are part of the platform, not an afterthought.
+            Honua mobile tooling extends the same platform into field collection, offline sync, and MAUI-based apps.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="mobile.html">View Mobile</a>


### PR DESCRIPTION
## Summary
- rewrite the main customer-facing pages to remove internal planning language
- simplify the homepage and protocol visuals by replacing crowded SVG diagrams with clearer comparison tables
- keep the Docker-first docs path and tighten the product, pricing, SDK, and mobile messaging

## Validation
- ./scripts/validate-site.sh
- ./scripts/build-dist.sh
