### PR TITLE
Tighten site positioning and platform vision

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,82 +62,92 @@
       <main>
         <section class="hero hero-home">
           <div class="hero-copy">
-            <p class="eyebrow">Cloud-Native Geospatial Platform</p>
-            <h1>A cloud-native GIS platform for migration, apps, mobile, and agents.</h1>
+            <p class="eyebrow">Modern GIS Platform</p>
+            <h1>Replace legacy GIS and standardize on a modern geospatial platform.</h1>
             <p class="lede">
-              Honua is a cloud-native geospatial platform and GIS runtime. It keeps ArcGIS-style and standards-based
-              clients working, adds <strong>gRPC</strong> for app and mobile performance, and adds <strong>MCP</strong>
-              for agent-native discovery and query workflows. One operational model, no per-user fees or protocol taxes.
+              Honua is for teams moving beyond ArcGIS seat growth, GeoServer operational drag, and point GIS tools
+              that stop at maps. It keeps GeoServices REST and standards-based clients working, gives new apps and
+              mobile teams a <strong>gRPC</strong> rail, and gives agents an <strong>MCP</strong>-native path into
+              geospatial data.
             </p>
             <div class="action-row">
-              <a class="button button-primary" href="protocols.html">See Supported APIs</a>
-              <a class="button button-secondary" href="docs.html">Get Started</a>
-              <a class="button button-ghost" href="pricing.html">Pricing and Licensing</a>
+              <a class="button button-primary" href="#switching">Why Teams Switch</a>
+              <a class="button button-secondary" href="platform.html">See Platform Vision</a>
+              <a class="button button-ghost" href="docs.html">Get Started</a>
             </div>
             <div class="pill-row" aria-label="Core capabilities">
-              <span class="pill">GeoServices REST</span>
+              <span class="pill">ArcGIS-compatible</span>
+              <span class="pill">GeoServer migration</span>
               <span class="pill">OGC API</span>
               <span class="pill">OData v4</span>
               <span class="pill">gRPC</span>
               <span class="pill">MCP</span>
-              <span class="pill">JavaScript / .NET / Python</span>
-              <span class="pill">Mobile SDK</span>
+              <span class="pill">SDKs + Mobile</span>
+              <span class="pill">Open-core pricing</span>
             </div>
             <div class="callout hero-callout">
-              Keep existing GIS clients working while giving developers, mobile teams, and agents modern access rails.
+              Start with low-risk replacement. Grow into one platform for apps, field workflows, analytics, automation, and managed delivery.
             </div>
           </div>
 
           <div class="hero-stack">
             <article class="surface-card surface-card-primary">
-              <p class="surface-label">What Honua Is</p>
-              <h2>Keep current GIS clients. Build faster apps. Add agent access.</h2>
+              <p class="surface-label">What Changes</p>
+              <h2>Start with migration. Grow into the full geospatial stack.</h2>
               <p>
-                Compatibility keeps migrations low-risk. gRPC improves application and mobile performance. MCP gives coding agents and assistants a supported way to work with geospatial data.
+                Honua begins as the safest way to replace a legacy GIS runtime and expands into the platform for APIs,
+                field apps, analytics, automation, and cloud-native operations.
               </p>
             </article>
             <article class="surface-card">
-              <p class="surface-label">Why teams switch</p>
+              <p class="surface-label">Proof</p>
               <ul class="bullet-list">
-                <li>Replace brittle legacy GIS stacks without breaking existing clients.</li>
-                <li>Adopt open standards and typed SDKs while preserving ArcGIS and OGC entry points.</li>
-                <li>Move app, mobile, and agent workflows onto gRPC and MCP instead of keeping everything trapped in legacy REST patterns.</li>
+                <li><strong>137/137</strong> OGC API Features tests passing</li>
+                <li><strong>16/16</strong> OGC API Tiles tests passing</li>
+                <li><strong>227/227</strong> WMS 1.3 tests passing</li>
+                <li><strong>118/118</strong> WMTS 1.0 tests passing</li>
               </ul>
+              <p>Compatibility matters more when it is backed by numbers, not just by migration promises.</p>
             </article>
           </div>
         </section>
 
         <section class="section stat-section">
           <div class="section-heading">
-            <p class="eyebrow">Platform Snapshot</p>
-            <h2>Everything teams need to adopt, migrate, and build.</h2>
+            <p class="eyebrow">Why Honua Exists</p>
+            <h2>GIS became too expensive, too closed, and too hard to operate.</h2>
+            <p class="section-copy">
+              Honua exists to break the old tradeoff between compatibility and modern delivery. Teams should not have to
+              choose between keeping their GIS clients alive and building something better.
+            </p>
           </div>
-          <div class="stat-grid">
-            <article class="stat-card">
-              <span class="stat-title">Protocols</span>
-              <p>GeoServices REST, OGC API, OData v4, vector tiles, WMS, WMTS, plus gRPC and MCP for newer application and agent workflows.</p>
+          <div class="note-grid">
+            <article class="note-card">
+              <h3>Compatibility without lock-in</h3>
+              <p>Keep ArcGIS-style and standards-based clients working while moving the platform underneath them forward.</p>
             </article>
-            <article class="stat-card">
-              <span class="stat-title">SDKs</span>
-              <p>JavaScript, .NET, Python, migration tooling, and an MCP package for agent workflows.</p>
+            <article class="note-card">
+              <h3>Operational excellence by default</h3>
+              <p>Cloud-native deployment, observability, and safer upgrades should be built into the platform, not left as custom services work.</p>
             </article>
-            <article class="stat-card">
-              <span class="stat-title">Mobile</span>
-              <p>.NET MAUI-first field foundation with GeoPackage offline storage, forms, sync, and gRPC-first transport.</p>
+            <article class="note-card">
+              <h3>Ownership over dependency</h3>
+              <p>Self-host, run in your own cloud, and adopt open SDKs and standards without a seat-based commercial trap.</p>
             </article>
-            <article class="stat-card">
-              <span class="stat-title">Licensing</span>
-              <p>No per-user fees, no protocol gating, no SDK tax. The server runtime is ELv2, while official SDKs, mobile tooling, and site assets are Apache 2.0.</p>
+            <article class="note-card">
+              <h3>Access for more than GIS specialists</h3>
+              <p>Expose geospatial data to developers, field teams, analysts, and agents through the tools they already use.</p>
             </article>
           </div>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Architecture</p>
-            <h2>How Honua fits together.</h2>
+            <p class="eyebrow">Access Model</p>
+            <h2>One platform. Three access lanes.</h2>
             <p class="section-copy">
-              Existing GIS clients enter through compatibility APIs. New apps and mobile clients use gRPC. Agents use MCP. All three paths reach the same Honua runtime and admin APIs.
+              Honua does not force a false choice between backward compatibility and better primitives. Teams can keep
+              what they already have, while standardizing new work on cleaner interfaces.
             </p>
           </div>
           <div class="table-wrap">
@@ -173,85 +183,129 @@
           </div>
         </section>
 
-        <section class="section section-contrast">
+        <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Commercial Model</p>
-            <h2>Pricing and licensing are part of the product.</h2>
+            <p class="eyebrow">Low Switching Cost</p>
+            <h2>Migration is designed to be staged, not heroic.</h2>
             <p class="section-copy">
-              Honua is designed to avoid the seat-count and protocol-gating model common in legacy GIS stacks.
+              Honua is not asking teams to rewrite everything at once. The migration path is built around import,
+              compatibility, scanning, codemods, and staged cutover.
             </p>
           </div>
-          <div class="mini-grid">
+          <div class="note-grid">
             <article class="note-card">
-              <h3>No seat pricing</h3>
-              <p>Adding analysts, viewers, or field operators does not force another licensing negotiation.</p>
+              <h3>Service import</h3>
+              <p>Bring in live Esri REST services and common spatial files so the first step is onboarding data and services, not replatforming every app.</p>
             </article>
             <article class="note-card">
-              <h3>No protocol or SDK add-ons</h3>
-              <p>GeoServices REST, OGC API, OData, SDKs, and mobile tooling are part of the product, not separate upsells.</p>
+              <h3>App converters and compat layers</h3>
+              <p>The JavaScript SDK includes usage scanning, compatibility wrappers, and codemod tooling for ArcGIS-heavy web applications.</p>
             </article>
             <article class="note-card">
-              <h3>Pay for depth, not permission</h3>
-              <p>Commercial tiers map to distributed runtime capability, governance, support, and enterprise readiness.</p>
+              <h3>Staged cutover</h3>
+              <p>Keep current GIS clients alive through GeoServices REST and OGC while new applications, mobile clients, and agents move onto gRPC, SDKs, and MCP.</p>
             </article>
             <article class="note-card">
-              <h3>Clear license split</h3>
-              <p>The server runtime is ELv2. Official SDKs, mobile tooling, and public collateral are Apache 2.0.</p>
+              <h3>Migration reporting</h3>
+              <p>Parity matrices, reconcile flows, and migration reports make the remaining manual work visible before teams commit to a switchover.</p>
             </article>
+          </div>
+        </section>
+
+        <section id="switching" class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Why Teams Switch</p>
+            <h2>Different GIS buyers have different reasons to leave.</h2>
+            <p class="section-copy">
+              Honua wins when it speaks directly to the problem in the stack a buyer already has, not when it assumes
+              every migration starts from the same pain.
+            </p>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Current stack</th>
+                  <th>Why buyers leave</th>
+                  <th>How Honua answers</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Esri / ArcGIS</td>
+                  <td>Per-user cost growth, extension taxes, and vendor lock-in around clients and workflows.</td>
+                  <td>Keep GeoServices-style access, remove seat pricing, add SDKs, mobile, and migration tooling on a platform you can self-host.</td>
+                </tr>
+                <tr>
+                  <td>GeoServer</td>
+                  <td>Operational drag, dated developer experience, and limited paths into mobile, SDKs, and agent workflows.</td>
+                  <td>Move to a cloud-native runtime with stronger developer tooling, clearer operations, and a broader platform destination.</td>
+                </tr>
+                <tr>
+                  <td>Mapbox / tiles-first stacks</td>
+                  <td>Great rendering, weak feature-service depth, and pricing or hosting limits outside the map front end.</td>
+                  <td>Serve features, tiles, standards, analytics, and field workflows from one self-hosted platform spine.</td>
+                </tr>
+                <tr>
+                  <td>Fulcrum / Survey123</td>
+                  <td>Field collection becomes another seat tax, another silo, and another vendor boundary.</td>
+                  <td>Bring field apps, offline sync, forms, and mobile SDKs into the same platform as the server runtime.</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">What You Get</p>
-            <h2>Runtime, SDKs, mobile, and operations in one platform.</h2>
+            <p class="eyebrow">Platform Ambition</p>
+            <h2>Honua is becoming the full stack geospatial platform.</h2>
             <p class="section-copy">
-              Honua combines a geospatial runtime, official SDKs, field tooling, migration helpers, and flexible deployment options.
+              Replacement is the entry point, not the end state. The same platform spine is extending across delivery,
+              field workflows, analytics, automation, and managed operation.
             </p>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
-              <p class="card-kicker">Server Runtime</p>
-              <h3>Multi-protocol geospatial runtime</h3>
+              <p class="card-kicker">Serving</p>
+              <h3>Replace the GIS runtime</h3>
               <p>
-                One PostGIS-backed core serving FeatureServer, MapServer, ImageServer, Geometry Service, OGC API,
-                OData, MVT, WMS, and WMTS.
+                Serve GeoServices REST, OGC APIs, OData, vector tiles, WMS, and WMTS from one PostGIS-backed core.
               </p>
             </article>
             <article class="card">
-              <p class="card-kicker">Developer Experience</p>
-              <h3>SDKs and quickstarts</h3>
+              <p class="card-kicker">Apps</p>
+              <h3>Build on SDKs, gRPC, and MCP</h3>
               <p>
-                Typed SDKs for JavaScript, .NET, and Python with migration tooling, quickstarts, release automation,
-                and compatibility guidance.
+                Give web apps, services, mobile clients, and agents a better path than legacy REST alone.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Mobile</p>
-              <h3>Field workflows without vendor lock-in</h3>
+              <h3>Own field collection and sync</h3>
               <p>
-                Mobile tooling covers offline GeoPackage sync, forms, background upload, and gRPC-first feature access.
+                Bring offline maps, forms, background sync, AR-assisted workflows, and sensor-aware collection into the same platform.
               </p>
             </article>
             <article class="card">
-              <p class="card-kicker">AI and Agents</p>
-              <h3>MCP for agents</h3>
+              <p class="card-kicker">Data Services</p>
+              <h3>Move beyond pure serving</h3>
               <p>
-                MCP adds discovery, schema inspection, query workflows, and agent integration without requiring custom scraping or glue code.
+                Add geocoding, routing, spatial analytics, and real-time data services on top of the same runtime and contracts.
               </p>
             </article>
             <article class="card">
-              <p class="card-kicker">Migration</p>
-              <h3>Replace ArcGIS and GeoServer with less risk</h3>
+              <p class="card-kicker">Formats</p>
+              <h3>Adopt cloud-native geospatial data paths</h3>
               <p>
-                Compatibility, standards, pricing clarity, and staged adoption keep replacement projects credible.
+                GeoParquet, FlatGeobuf, PMTiles, and COG should sit inside the platform, not beside it.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Operations</p>
-              <h3>Cloud-native deployment choices</h3>
+              <h3>Operate it yourself or consume it as a service</h3>
               <p>
-                Docker, Kubernetes, AWS, Azure, and serverless targets stay visible because deploy flexibility is part of the product value.
+                Self-host in Docker, Kubernetes, AWS, and Azure today, then grow toward managed cloud and operator-assisted delivery.
               </p>
             </article>
           </div>
@@ -261,18 +315,17 @@
           <div class="detail-grid">
             <article class="detail-card">
               <p class="eyebrow">Proof</p>
-              <h2>Verified compatibility and standards support.</h2>
+              <h2>Compatibility is backed by hard evidence.</h2>
               <p>
-                Honua publishes compatibility and conformance evidence across OGC API, WMS, WMTS, GeoServices-style APIs, and SDK compatibility guidance.
+                OGC API, WMS, and WMTS conformance results are published with exact passing counts, so buyers can inspect the evidence instead of taking a compatibility claim on faith.
               </p>
               <a class="text-link" href="protocols.html">Explore protocol coverage</a>
             </article>
             <article class="detail-card">
-              <p class="eyebrow">Licensing</p>
-              <h2>Licensing is explicit, not implied.</h2>
+              <p class="eyebrow">Economics</p>
+              <h2>Honua removes the seat-tax growth curve.</h2>
               <p>
-                The server follows an open-core ELv2 model while the official SDKs and mobile/tooling repos use Apache 2.0.
-                That distinction matters for trust, procurement, and migration conversations.
+                The pricing model is explicit: no per-user licensing, no protocol add-ons, no SDK tax, and a clear split between free community use and quote-based commercial runtime depth.
               </p>
               <a class="text-link" href="pricing.html">Read pricing and licensing</a>
             </article>
@@ -281,38 +334,38 @@
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Choose a Path</p>
-            <h2>Start with the page that matches your role.</h2>
+            <p class="eyebrow">Start Here</p>
+            <h2>Choose the path that matches your team.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card card-link">
-              <h3>Platform</h3>
-              <p>See the runtime, admin APIs, deployment targets, and migration approach.</p>
+              <h3>GIS modernization lead</h3>
+              <p>See the migration path, deployment model, and the broader platform your team can standardize on.</p>
               <a class="text-link" href="platform.html">Go to Platform</a>
             </article>
             <article class="card card-link">
-              <h3>Protocols</h3>
-              <p>See the APIs and formats Honua supports for GIS clients, analytics, applications, and agents.</p>
-              <a class="text-link" href="protocols.html">Go to Protocols</a>
-            </article>
-            <article class="card card-link">
-              <h3>SDKs</h3>
-              <p>Choose JavaScript, .NET, Python, or MCP based on how your team builds and integrates.</p>
+              <h3>Developer</h3>
+              <p>See the SDKs, gRPC rail, MCP path, quickstarts, and the interfaces teams can build on.</p>
               <a class="text-link" href="sdks.html">Go to SDKs</a>
             </article>
             <article class="card card-link">
-              <h3>Mobile</h3>
-              <p>See MAUI-first field collection, offline sync, and mobile tooling without per-user licensing.</p>
+              <h3>Field operations lead</h3>
+              <p>See offline sync, MAUI tooling, AR and IoT direction, and why Honua can replace seat-priced field tools.</p>
               <a class="text-link" href="mobile.html">Go to Mobile</a>
             </article>
             <article class="card card-link">
-              <h3>Pricing</h3>
-              <p>Review edition boundaries, license posture, and why Honua does not charge by user seat, protocol, or client library.</p>
+              <h3>Data and analytics team</h3>
+              <p>See OData, standards APIs, analytics direction, cloud-native formats, and where the platform is heading next.</p>
+              <a class="text-link" href="protocols.html">Go to Protocols</a>
+            </article>
+            <article class="card card-link">
+              <h3>Platform and DevOps owner</h3>
+              <p>Review deployment options, runtime economics, governance boundaries, and how commercial packaging is structured.</p>
               <a class="text-link" href="pricing.html">Go to Pricing</a>
             </article>
             <article class="card card-link">
-              <h3>Docs</h3>
-              <p>Start with a quickstart, first API call, SDK install path, and direct links into the deeper docs.</p>
+              <h3>Hands-on evaluator</h3>
+              <p>Run Honua in Docker, make a request, install one SDK, and decide whether the platform fits your stack.</p>
               <a class="text-link" href="docs.html">Go to Docs</a>
             </article>
           </div>

--- a/mobile.html
+++ b/mobile.html
@@ -36,16 +36,17 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Mobile</p>
-          <h1>Build field workflows on the same Honua platform.</h1>
+          <h1>Build open field apps without the seat-priced mobile trap.</h1>
           <p class="page-intro">
-            Honua includes .NET MAUI mobile tooling for offline maps, forms, sync, background upload, and fast feature access.
+            Honua includes .NET MAUI mobile tooling for offline maps, forms, sync, background upload, fast feature
+            access, and the broader field direction most GIS platforms never reach.
           </p>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Mobile Positioning</p>
-            <h2>Core mobile capabilities.</h2>
+            <p class="eyebrow">Why It Matters</p>
+            <h2>Mobile is one of Honua's strongest wedges.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
@@ -56,7 +57,7 @@
             <article class="card">
               <p class="card-kicker">Transport</p>
               <h3>gRPC-first when it matters</h3>
-              <p>Unary and streaming access patterns support large feature retrieval and collaboration flows with lower overhead than pure REST polling.</p>
+              <p>Unary and streaming access patterns support large feature retrieval and collaboration flows with much less overhead than pure REST polling.</p>
             </article>
             <article class="card">
               <p class="card-kicker">Framework</p>
@@ -69,21 +70,60 @@
               <p>Dynamic forms, validation, calculated fields, duplicate detection, and record lifecycle tools support real field operations.</p>
             </article>
             <article class="card">
-              <p class="card-kicker">Sync</p>
-              <h3>Background upload and conflict handling</h3>
-              <p>Connectivity-aware background sync and conflict strategies make the mobile client usable in day-to-day operations.</p>
+              <p class="card-kicker">AR + IoT</p>
+              <h3>Go past basic forms</h3>
+              <p>Honua's field direction includes AR-assisted workflows and sensor-aware collection with Bluetooth LE, LoRa, and other device integrations.</p>
             </article>
             <article class="card">
               <p class="card-kicker">Economics</p>
               <h3>No per-user mobile tax</h3>
-              <p>Mobile workflows do not carry a separate per-seat field subscription tax.</p>
+              <p>Field workflows do not carry a separate per-seat mobile subscription, so adoption can expand without another licensing curve.</p>
             </article>
           </div>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Components</p>
+            <p class="eyebrow">Competitive Position</p>
+            <h2>The field economics are different.</h2>
+            <p class="section-copy">
+              Fulcrum and Survey123 are not just feature comparisons. They create a separate seat-priced product line
+              for field teams. Honua folds mobile into the platform.
+            </p>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Product</th>
+                  <th>Typical pricing posture</th>
+                  <th>What teams get</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Honua Mobile</td>
+                  <td>No separate field-user license</td>
+                  <td>MAUI-native mobile stack, offline GeoPackage sync, forms, gRPC-first access, and a path toward AR and IoT workflows.</td>
+                </tr>
+                <tr>
+                  <td>Fulcrum</td>
+                  <td>Typically <strong>$99-299 per user per month</strong></td>
+                  <td>Field collection with a separate vendor boundary and recurring per-user field cost.</td>
+                </tr>
+                <tr>
+                  <td>Survey123</td>
+                  <td>Typically <strong>$25-100 per user per month</strong></td>
+                  <td>ArcGIS-tied form workflows with another seat-driven licensing layer.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">SDK Building Blocks</p>
             <h2>Core mobile components.</h2>
           </div>
           <div class="table-wrap">
@@ -124,17 +164,17 @@
         <section class="section section-contrast">
           <div class="detail-grid">
             <article class="detail-card">
-              <p class="eyebrow">Positioning</p>
-              <h2>Mobile extends Honua beyond the server.</h2>
+              <p class="eyebrow">Performance</p>
+              <h2>gRPC changes what mobile GIS can feel like.</h2>
               <p>
-                With mobile tooling in place, Honua covers collection, sync, data access, and delivery instead of stopping at server replacement.
+                Honua mobile benchmark and protocol work targets roughly 60-70% lower bandwidth and 5x faster loading than legacy mobile GIS patterns built on XML and REST-heavy sync.
               </p>
             </article>
             <article class="detail-card">
-              <p class="eyebrow">Pricing</p>
-              <h2>No separate field-user tax.</h2>
+              <p class="eyebrow">Positioning</p>
+              <h2>Mobile makes Honua a platform, not just a server replacement.</h2>
               <p>
-                Field teams do not need a separate per-user mobile subscription. Mobile capabilities follow the same no-seat posture as the rest of the platform.
+                Once field collection, sync, forms, and device workflows sit on the same platform as the runtime, the switching case against legacy GIS stacks becomes much larger.
               </p>
             </article>
           </div>

--- a/platform.html
+++ b/platform.html
@@ -36,34 +36,42 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Platform</p>
-          <h1>Honua is a platform, not just a server.</h1>
+          <h1>A full-stack geospatial platform, not another feature server.</h1>
           <p class="page-intro">
-            Honua combines a multi-protocol geospatial runtime, admin APIs, official SDKs, mobile tooling, MCP access,
-            migration helpers, and cloud deployment options in one platform.
+            Honua starts with server replacement and grows into the platform for data services, apps, mobile,
+            analytics, agent access, and managed delivery.
           </p>
         </section>
 
         <section class="section section-contrast">
           <div class="section-heading">
             <p class="eyebrow">Differentiation</p>
-            <h2>Built for compatibility and modern delivery.</h2>
+            <h2>Migration is the beachhead. Platform consolidation is the play.</h2>
             <p class="section-copy">
-              GeoServices REST and OGC compatibility let teams migrate without breaking clients. gRPC and MCP give new applications, mobile clients, and agents a better interface than legacy GIS stacks.
+              The strongest wedge is replacing legacy GIS without breaking clients. The larger opportunity is to unify
+              serving, field workflows, analytics, automation, and operations on one contract set.
             </p>
           </div>
           <div class="detail-grid">
             <article class="detail-card detail-card-accent">
-              <p class="eyebrow">gRPC</p>
-              <h2>Fast path for apps, SDKs, and mobile</h2>
+              <p class="eyebrow">Compatibility</p>
+              <h2>Keep the old clients. Fix the operating model.</h2>
               <p>
-                gRPC is the typed binary rail for application builders and field workflows. It is part of the product’s technical edge, not a buried implementation detail.
+                GeoServices REST and OGC compatibility make migration credible. Buyers do not need to rip out every
+                client on day one to move to a better platform.
               </p>
+              <ul class="bullet-list">
+                <li>Service import gets data and services into Honua quickly.</li>
+                <li>Migration tooling and codemods reduce rewrite cost for app teams.</li>
+                <li>Staged cutover keeps legacy clients alive while new paths move to SDKs, gRPC, and MCP.</li>
+              </ul>
             </article>
             <article class="detail-card detail-card-spot">
-              <p class="eyebrow">MCP</p>
-              <h2>Agent path into the platform</h2>
+              <p class="eyebrow">New Rails</p>
+              <h2>Give the next generation of apps better interfaces.</h2>
               <p>
-                MCP gives AI assistants and coding agents a supported path for discovery, schema inspection, and query workflows.
+                gRPC and MCP are not side features. They are the forward path for application builders, mobile teams,
+                and agent-native geospatial workflows.
               </p>
             </article>
           </div>
@@ -71,50 +79,72 @@
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Core Layers</p>
-            <h2>The platform in one view.</h2>
+            <p class="eyebrow">Visual</p>
+            <h2>The current cloud-native deployment spine.</h2>
+            <p class="section-copy">
+              Honua already ties clients, ingress, runtime, PostGIS, caching, storage, and monitoring into one
+              deployment model instead of treating GIS as a one-off island in the stack.
+            </p>
+          </div>
+          <div class="image-panel">
+            <img
+              class="platform-illustration"
+              src="assets/honua-cloud-native-gis.png"
+              alt="Diagram showing GIS clients and analytics tools reaching Honua through ingress, with PostGIS, Redis, object storage, and monitoring behind the runtime."
+            />
+            <p class="image-caption">
+              Current deployment reference: one cloud-native runtime behind standard ingress, backed by PostGIS,
+              optional Redis, object storage, and observability.
+            </p>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Platform Spine</p>
+            <h2>The layers that make the full stack possible.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
               <p class="card-kicker">Runtime</p>
-              <h3>Server core</h3>
+              <h3>Compatibility and serving core</h3>
               <p>
-                The runtime serves GeoServices REST, OGC API, OData, tiles, WMS, WMTS, unary gRPC, and MCP-adjacent discovery/query access from one PostGIS-backed system.
+                Serve GeoServices REST, OGC API, OData, tiles, WMS, WMTS, unary gRPC, and MCP-backed discovery/query access from one PostGIS-backed system.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Admin</p>
-              <h3>Admin APIs and UI</h3>
+              <h3>Admin APIs and control center</h3>
               <p>
-                Admin APIs and the admin UI handle publishing, governance, and deployment coordination.
+                Publishing, governance, and rollout coordination belong inside the platform, not in scattered scripts and runbooks.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Integrations</p>
-              <h3>SDKs and agents</h3>
+              <h3>SDKs, gRPC, and agents</h3>
               <p>
-                JavaScript, .NET, Python, migration utilities, and the MCP package give developers a faster path from evaluation to production.
+                JavaScript, .NET, Python, migration tooling, and MCP give developers a faster path from evaluation to production.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Mobile</p>
               <h3>Field workflows</h3>
               <p>
-                The MAUI-first mobile track adds offline GeoPackage sync, form workflows, background upload, and gRPC-first access for field operations.
+                The MAUI-first mobile stack brings offline sync, forms, AR-assisted workflows, and sensor-aware collection into the same platform.
               </p>
             </article>
             <article class="card">
-              <p class="card-kicker">Migration</p>
-              <h3>Migration path</h3>
+              <p class="card-kicker">Data</p>
+              <h3>Data services and modern formats</h3>
               <p>
-                ArcGIS and GeoServer replacement stays practical through compatibility, staged migration, standards support, and predictable licensing.
+                Geocoding, routing, analytics, GeoParquet, FlatGeobuf, PMTiles, and COG belong on top of the same platform contracts.
               </p>
             </article>
             <article class="card">
-              <p class="card-kicker">Operations</p>
-              <h3>Deploy where the team already runs</h3>
+              <p class="card-kicker">Cloud</p>
+              <h3>Self-hosted or managed</h3>
               <p>
-                Docker, Kubernetes, AWS, Azure, serverless, and infrastructure-as-code stay visible because deployment freedom is part of the product.
+                Docker, Kubernetes, AWS, Azure, serverless targets, and managed cloud can all share the same product spine.
               </p>
             </article>
           </div>
@@ -122,53 +152,53 @@
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Product Areas</p>
-            <h2>How the main product areas fit together.</h2>
+            <p class="eyebrow">Platform Direction</p>
+            <h2>Where the stack expands next.</h2>
           </div>
           <div class="table-wrap">
             <table>
               <thead>
                 <tr>
                   <th>Area</th>
-                  <th>What it includes</th>
+                  <th>What Honua is building toward</th>
                   <th>Why it matters</th>
                 </tr>
               </thead>
               <tbody>
                 <tr>
-                  <td>Honua Server</td>
-                  <td>Protocol runtime, admin API, deployment target, migration destination</td>
-                  <td>Compatibility, conformance, standards, operational footprint, and licensing model</td>
+                  <td>Serving and compatibility</td>
+                  <td>Protocol runtime, migration destination, standards surface, admin API, and deployment target</td>
+                  <td>It is the lowest-risk path out of legacy GIS and the foundation every other surface builds on.</td>
                 </tr>
                 <tr>
-                  <td>Admin APIs and UI</td>
-                  <td>Publishing, governance, environment management, rollout direction</td>
-                  <td>Operational confidence, governance, and deployment coordination</td>
+                  <td>Mobile and field operations</td>
+                  <td>Offline sync, forms, background upload, AR-assisted workflows, IoT and sensor-aware collection</td>
+                  <td>Most GIS platforms still stop at serving. Honua is pushing the stack all the way into field execution.</td>
                 </tr>
                 <tr>
-                  <td>SDKs</td>
-                  <td>Official libraries for JavaScript, .NET, and Python</td>
-                  <td>Typed clients, quickstarts, migration tooling, and compatibility contracts</td>
+                  <td>Data services</td>
+                  <td>Geocoding, routing, spatial analytics, H3-style aggregation, and streaming data flows</td>
+                  <td>That is how Honua becomes a broader geospatial application platform, not just a serving runtime.</td>
                 </tr>
                 <tr>
-                  <td>Mobile</td>
-                  <td>Field collection and offline workflows</td>
-                  <td>GeoPackage sync, forms, MAUI, background sync, and gRPC-first performance</td>
+                  <td>Formats and storage</td>
+                  <td>GeoParquet, FlatGeobuf, PMTiles, COG, and modern data movement patterns</td>
+                  <td>Cloud-native geospatial stacks need modern file and archive formats, not just database tables and shapefiles.</td>
                 </tr>
                 <tr>
-                  <td>MCP</td>
-                  <td>Agent and AI integration access</td>
-                  <td>Discovery, schema inspection, filtered query workflows, and secure tool access</td>
+                  <td>Apps</td>
+                  <td>Portal, dashboards, open data hub, and low-code geospatial application surfaces</td>
+                  <td>The platform can own more of the user-facing stack instead of stopping at APIs.</td>
                 </tr>
                 <tr>
-                  <td>Private operator layer</td>
-                  <td>Enterprise or partner-led AI DevOps/copilot tooling</td>
-                  <td>Keep it clearly separate from the open-core runtime: rollout planning, delegated ops, and implementation workflows can be private without undermining the public platform.</td>
+                  <td>Managed cloud and operator tooling</td>
+                  <td>Honua Cloud, deployment orchestration, rollout evidence, and partner or enterprise operator workflows</td>
+                  <td>Buying GIS as a platform is easier when self-hosted and managed paths share the same core contracts.</td>
                 </tr>
                 <tr>
-                  <td>Pricing and Editions</td>
-                  <td>Pricing, licensing, and edition model</td>
-                  <td>No per-user fees, no protocol gating, open-core boundary, and clear edition differences</td>
+                  <td>AI and automation</td>
+                  <td>AI spatial agent, geoprocessing, GeoETL, and private operator copilot flows</td>
+                  <td>Honua can expose geospatial workflows to both users and agents without giving up governance boundaries.</td>
                 </tr>
               </tbody>
             </table>
@@ -178,15 +208,15 @@
         <section class="section section-contrast">
           <div class="note-grid">
             <article class="note-card">
-              <h3>Why teams buy a platform, not a point product</h3>
+              <h3>Why the platform strategy matters</h3>
               <p>
-                Honua combines compatibility, SDKs, mobile tooling, modern APIs, and operations so teams do not have to assemble those pieces themselves.
+                GIS buyers are tired of stitching together one server, one tile service, one field app, one analytics tool, and one licensing conversation for each.
               </p>
             </article>
             <article class="note-card">
-              <h3>How the pieces work together</h3>
+              <h3>Why this is credible</h3>
               <p>
-                The runtime, admin APIs, SDKs, mobile tooling, pricing model, and private operator layer all build on the same platform foundation.
+                The same shared runtime, admin contracts, SDKs, pricing model, and deployment substrates make the larger platform direction believable instead of aspirational fluff.
               </p>
             </article>
           </div>

--- a/pricing.html
+++ b/pricing.html
@@ -36,64 +36,75 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Pricing and Licensing</p>
-          <h1>No seat tax. No protocol tax. No SDK tax.</h1>
+          <h1>Pricing that scales with deployment depth, not user count.</h1>
           <p class="page-intro">
-            Honua uses an open-core model with clear runtime boundaries: no per-user fees, no protocol gating,
-            no add-on SDK licensing, and no credit-style meter. Commercial tiers start when a team needs coordinated
-            scale, streaming depth, governance, and enterprise support.
+            Honua uses an open-core model with clear runtime boundaries: community is free, commercial is quote-based,
+            and the package structure is public. Teams do not pay more because they added more viewers, more field
+            staff, more standards, more SDKs, or more agent workflows.
           </p>
           <div class="callout">
-            You do not pay more because you added more users, more client apps, more standards, more field devices, or more agent workflows.
+            Commercial pricing is structured around three buckets: <strong>software subscription</strong>,
+            <strong>support tier</strong>, and optional <strong>professional services</strong>.
           </div>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Buyer Snapshot</p>
-            <h2>Pricing is simple to explain.</h2>
+            <p class="eyebrow">Commercial Model</p>
+            <h2>Simple enough for buyers to understand quickly.</h2>
           </div>
           <div class="mini-grid">
             <article class="note-card">
-              <h3>No per-user fees</h3>
-              <p>Adding analysts, viewers, operators, or field staff does not trigger a new seat purchase.</p>
+              <h3>Community</h3>
+              <p>Free self-hosted use under ELv2 for evaluation, internal deployment, and smaller production footprints.</p>
             </article>
             <article class="note-card">
-              <h3>No protocol tax</h3>
-              <p>GeoServices REST, OGC API, OData, tiles, and SDK access are part of adoption, not hidden add-ons.</p>
+              <h3>Pro</h3>
+              <p>Quote-based per-node commercial subscription when a team needs coordinated scale, streaming depth, and stronger runtime capability.</p>
             </article>
             <article class="note-card">
-              <h3>No SDK surcharge</h3>
-              <p>JavaScript, .NET, Python, mobile tooling, and MCP are included without extra client-side licensing friction.</p>
+              <h3>Enterprise</h3>
+              <p>Annual contract for governance, premium support, change management, compliance controls, and multi-team production requirements.</p>
             </article>
             <article class="note-card">
-              <h3>Pay for production depth</h3>
-              <p>Commercial tiers are about distributed coordination, streaming, governance, support, and enterprise controls.</p>
+              <h3>What stays public</h3>
+              <p><strong>No per-user fees</strong>, plus protocols, SDKs, mobile tooling, and the base MCP data-access layer remain visible and adoptable across the platform.</p>
             </article>
           </div>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">What We Refuse To Monetize</p>
-            <h2>The commercial boundary is explicit.</h2>
+            <p class="eyebrow">How Buying Works</p>
+            <h2>The boundary is explicit.</h2>
           </div>
-          <div class="mini-grid">
-            <article class="note-card">
-              <h3>Users and operators</h3>
-              <p>Scale your user base without buying new seats every time a viewer, analyst, or field user appears.</p>
-            </article>
-            <article class="note-card">
-              <h3>Protocols</h3>
-              <p>GeoServices REST, OGC API, OData, tiles, and SDK access stay visible because they are part of adoption, not premium upsell bait.</p>
-            </article>
-            <article class="note-card">
-              <h3>SDKs and clients</h3>
-              <p>Developer libraries, mobile tooling, and client access are included instead of split into optional taxes.</p>
-            </article>
-            <article class="note-card">
-              <h3>What commercial tiers actually cover</h3>
-              <p>Higher editions map to distributed coordination, streaming depth, governance, support, and enterprise controls.</p>
-            </article>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Category</th>
+                  <th>How Honua treats it</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Users and field staff</td>
+                  <td>Not monetized per seat. Adding analysts, viewers, operators, and field workers should not trigger a relicensing event.</td>
+                </tr>
+                <tr>
+                  <td>Protocols and SDKs</td>
+                  <td>Not hidden behind add-ons. GeoServices REST, OGC APIs, OData, SDKs, mobile tooling, and base MCP are part of adoption.</td>
+                </tr>
+                <tr>
+                  <td>Commercial upsell</td>
+                  <td>Focused on coordinated scale, governance, support, streaming depth, and enterprise controls rather than artificial product crippling.</td>
+                </tr>
+                <tr>
+                  <td>Deployment costs</td>
+                  <td>Customer cloud spend, managed database spend, and professional services stay separate unless explicitly bundled in an order form.</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </section>
 
@@ -123,17 +134,17 @@
         <section class="section section-contrast">
           <div class="detail-grid">
             <article class="detail-card">
-              <p class="eyebrow">What You Never Pay For</p>
-              <h2>User count, protocol usage, or client access.</h2>
+              <p class="eyebrow">Budgeting</p>
+              <h2>Commercial pricing is quote-based today, not hidden.</h2>
               <p>
-                Honua is designed to avoid the pricing shape many teams are trying to leave behind: every new viewer, field operator, protocol, or SDK becoming a separate purchasing event.
+                Honua is explicit that community is free, commercial packaging is public, and final commercial pricing is still quote-based while the launch motion matures.
               </p>
             </article>
             <article class="detail-card">
-              <p class="eyebrow">What You Do Pay For</p>
-              <h2>Coordinated scale, governance, and enterprise confidence.</h2>
+              <p class="eyebrow">Comparison</p>
+              <h2>What most buyers are actually escaping.</h2>
               <p>
-                Paid editions focus on distributed cache, streaming depth, support, governance, compliance, and change management instead of artificial product crippling.
+                Most migration buyers are comparing against ArcGIS seat growth, extension taxes, field-user licensing, and procurement friction. Honua is designed to remove that pricing shape entirely.
               </p>
             </article>
           </div>

--- a/protocols.html
+++ b/protocols.html
@@ -36,41 +36,43 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Protocols</p>
-          <h1>APIs and protocols for GIS clients, applications, analytics, and agents.</h1>
+          <h1>One runtime. Three access lanes.</h1>
           <p class="page-intro">
             Honua brings GeoServices REST, OGC API, OData, gRPC, MCP, and cloud-native tiles together in one runtime.
-            Existing GIS clients can keep working while new applications, mobile clients, and AI agents use newer access patterns.
+            Legacy GIS clients can keep working while new apps, mobile teams, analysts, and agents move onto better interfaces.
           </p>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">Modern APIs</p>
-            <h2>New application and agent access.</h2>
+            <p class="eyebrow">Differentiated Rails</p>
+            <h2>The protocols that move Honua beyond legacy GIS.</h2>
           </div>
           <div class="detail-grid">
             <article class="detail-card detail-card-accent">
               <p class="eyebrow">gRPC</p>
               <h2>Application and mobile performance rail</h2>
               <p>
-                gRPC gives applications and mobile clients a fast typed path for high-throughput requests, service-to-service calls, and richer field workflows.
+                gRPC gives applications and mobile clients a typed binary rail for higher-throughput requests,
+                service-to-service calls, and richer field workflows than legacy REST and XML patterns can support.
               </p>
               <ul class="bullet-list">
-                <li>Strong fit for typed SDKs and mobile field clients.</li>
-                <li>Unary access is available in the base platform.</li>
-                <li>Streaming is the commercial path for larger workloads.</li>
+                <li>Strong fit for typed SDKs, field apps, and service integrations.</li>
+                <li>Honua mobile protocol work targets roughly 60-70% lower bandwidth and 5x faster loading in benchmark/spec work.</li>
+                <li>The protocol direction is aimed at OGC working-group submission, not a private wire format moat.</li>
               </ul>
             </article>
             <article class="detail-card detail-card-spot">
               <p class="eyebrow">MCP</p>
               <h2>Agent-native geospatial access rail</h2>
               <p>
-                MCP lets coding agents, copilots, and analyst assistants discover services, inspect schemas, and run filtered queries through a supported interface.
+                MCP lets coding agents, copilots, and analyst assistants discover services, inspect schemas, and run
+                filtered queries through a supported interface instead of brittle scraping and custom wrappers.
               </p>
               <ul class="bullet-list">
-                <li>Discovery and query workflows for AI assistants.</li>
+                <li>Discovery and query workflows for AI assistants and coding agents.</li>
                 <li>Direct bridge from geospatial systems into agent ecosystems.</li>
-                <li>A meaningful differentiation point versus legacy GIS stacks.</li>
+                <li>A meaningful differentiation point versus legacy GIS stacks that barely acknowledge agent access.</li>
               </ul>
             </article>
           </div>
@@ -119,6 +121,38 @@
           </div>
           <div class="callout">
             One Honua deployment can support these access patterns at the same time, so teams do not need separate products for migration, analytics, mobile, and agent workflows.
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Conformance</p>
+            <h2>Standards support is backed by exact passing counts.</h2>
+            <p class="section-copy">
+              Honua does not just say it supports standards. It publishes concrete conformance results that buyers can
+              inspect before they commit.
+            </p>
+          </div>
+          <div class="mini-grid">
+            <article class="note-card">
+              <h3>OGC API Features</h3>
+              <p><strong>137/137</strong> CITE tests passing.</p>
+            </article>
+            <article class="note-card">
+              <h3>OGC API Tiles</h3>
+              <p><strong>16/16</strong> CITE tests passing.</p>
+            </article>
+            <article class="note-card">
+              <h3>WMS 1.3</h3>
+              <p><strong>227/227</strong> tests passing.</p>
+            </article>
+            <article class="note-card">
+              <h3>WMTS 1.0</h3>
+              <p><strong>118/118</strong> tests passing.</p>
+            </article>
+          </div>
+          <div class="callout">
+            Those numbers matter because standards buyers want proof, not a checklist slide.
           </div>
         </section>
 
@@ -207,10 +241,11 @@
         <section class="section section-contrast">
           <div class="detail-grid">
             <article class="detail-card">
-              <p class="eyebrow">Proof</p>
-              <h2>Verified standards support.</h2>
+              <p class="eyebrow">Engineering</p>
+              <h2>The protocol layer is built for production, not for demos.</h2>
               <p>
-                Honua already publishes concrete OGC API, WMS, and WMTS compatibility evidence so teams can evaluate standards support before they commit.
+                Honua pairs the protocol surface with PostGIS-native tile generation, cloud-native deployment targets,
+                and optional Redis-backed coordination so the interface story is credible operationally too.
               </p>
             </article>
             <article class="detail-card">

--- a/styles.css
+++ b/styles.css
@@ -667,6 +667,26 @@ pre {
   line-height: 1.65;
 }
 
+.image-panel {
+  padding: 18px;
+  border: 1px solid rgba(19, 37, 47, 0.08);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 32px rgba(19, 37, 47, 0.08);
+}
+
+.platform-illustration {
+  width: 100%;
+  height: auto;
+  border-radius: 18px;
+}
+
+.image-caption {
+  margin: 14px 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
 .contact-grid {
   grid-template-columns: minmax(0, 1fr) minmax(320px, 0.96fr);
 }


### PR DESCRIPTION
## Summary
- sharpen the homepage around mission, proof, switching cost, and competitive framing
- rewrite the platform, protocols, mobile, and pricing pages around the broader Honua vision
- add a real platform visual and tighten the buying-model copy

## Validation
- ./scripts/validate-site.sh
- ./scripts/build-dist.sh

Related to #8
Related to #9