### PR TITLE
Add trust pages and harden the MVP quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@ Repository layout:
 - `mobile.html` - mobile and field workflow page
 - `pricing.html` - pricing and licensing page
 - `docs.html` - quickstart and docs hub
+- `privacy.html` - privacy and cookie notice
+- `terms.html` - site terms of use
+- `security.html` - security contact and DPA posture
 - `styles.css` - site styles
 - `assets/` - static assets
 - `_headers` - deployment response headers (CSP, clickjacking, and related security headers)
-- `scripts/validate-site.sh` - CI validation entrypoint for content, security headers, and workflow pinning
+- `scripts/build-dist.sh` - build the deployable static artifact
+- `scripts/validate-security-headers.sh` - validate live security headers when a target URL is configured
+- `scripts/validate-workflow-pinning.sh` - verify workflow actions remain pinned
 - `.github/workflows/` - CI/deploy workflows

--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -1,8 +1,121 @@
-window.dataLayer = window.dataLayer || [];
+(function () {
+  const consentKey = "honua_cookie_consent";
+  const accepted = "accepted";
+  const declined = "declined";
+  const bannerId = "honua-cookie-banner";
+  const analyticsId = "G-V7YTZL98ML";
+  let analyticsLoaded = false;
 
-function gtag() {
-  window.dataLayer.push(arguments);
-}
+  function readConsent() {
+    try {
+      return window.localStorage.getItem(consentKey);
+    } catch {
+      return null;
+    }
+  }
 
-gtag("js", new Date());
-gtag("config", "G-V7YTZL98ML");
+  function writeConsent(value) {
+    try {
+      window.localStorage.setItem(consentKey, value);
+    } catch {
+      // Ignore storage failures and keep the site usable.
+    }
+  }
+
+  function clearConsent() {
+    try {
+      window.localStorage.removeItem(consentKey);
+    } catch {
+      // Ignore storage failures and keep the site usable.
+    }
+  }
+
+  function gtag() {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push(arguments);
+  }
+
+  function loadAnalytics() {
+    if (analyticsLoaded) {
+      return;
+    }
+
+    analyticsLoaded = true;
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = gtag;
+    window.gtag("js", new Date());
+    window.gtag("config", analyticsId, { anonymize_ip: true });
+
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = "https://www.googletagmanager.com/gtag/js?id=" + encodeURIComponent(analyticsId);
+    document.head.appendChild(script);
+  }
+
+  function removeBanner() {
+    const banner = document.getElementById(bannerId);
+    if (banner) {
+      banner.remove();
+    }
+  }
+
+  function setConsent(value) {
+    writeConsent(value);
+    if (value === accepted) {
+      loadAnalytics();
+    }
+    removeBanner();
+  }
+
+  function renderBanner() {
+    const consent = readConsent();
+    if (consent === accepted || consent === declined || !document.body || document.getElementById(bannerId)) {
+      return;
+    }
+
+    const banner = document.createElement("section");
+    banner.id = bannerId;
+    banner.className = "cookie-banner";
+    banner.setAttribute("aria-label", "Cookie consent");
+    banner.innerHTML =
+      '<div class="cookie-banner-copy">' +
+      '<strong>Cookie choice</strong>' +
+      "<p>Honua only loads analytics after consent. Declining keeps the site functional and skips analytics cookies. See <a href=\"privacy.html#cookies\">cookie details</a>.</p>" +
+      "</div>" +
+      '<div class="cookie-banner-actions">' +
+      '<button class="button button-secondary" type="button" data-cookie-accept>Accept analytics</button>' +
+      '<button class="button button-ghost" type="button" data-cookie-decline>Decline</button>' +
+      "</div>";
+
+    banner.querySelector("[data-cookie-accept]").addEventListener("click", function () {
+      setConsent(accepted);
+    });
+
+    banner.querySelector("[data-cookie-decline]").addEventListener("click", function () {
+      setConsent(declined);
+    });
+
+    document.body.appendChild(banner);
+  }
+
+  function bindResetButtons() {
+    document.querySelectorAll("[data-cookie-reset]").forEach(function (button) {
+      button.addEventListener("click", function () {
+        clearConsent();
+        removeBanner();
+        renderBanner();
+      });
+    });
+  }
+
+  function init() {
+    if (readConsent() === accepted) {
+      loadAnalytics();
+    }
+
+    renderBanner();
+    bindResetButtons();
+  }
+
+  document.addEventListener("DOMContentLoaded", init);
+})();

--- a/docs.html
+++ b/docs.html
@@ -10,6 +10,7 @@
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
   </head>
   <body>
     <div class="site-shell">
@@ -46,7 +47,7 @@
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Quickstart</p>
-            <h2>Zero to a working request.</h2>
+            <h2>Zero to an authenticated request.</h2>
           </div>
           <article class="card">
             <p class="card-kicker">Step 1</p>
@@ -57,29 +58,69 @@ docker run -d --name honua-postgis --network honua \
   -e POSTGRES_DB=honua \
   -e POSTGRES_USER=postgres \
   -e POSTGRES_PASSWORD=postgres \
-  postgis/postgis:17-3.6
+  postgis/postgis:17-3.5-alpine
+
+docker exec honua-postgis pg_isready -U postgres -d honua
 
 docker run -d --name honua-server --network honua -p 8080:8080 \
   -e ConnectionStrings__DefaultConnection="Host=honua-postgis;Database=honua;Username=postgres;Password=postgres" \
-  -e HONUA_ADMIN_PASSWORD="change-me" \
+  -e HONUA_ADMIN_PASSWORD="change-me-now" \
+  -e Security__ConnectionEncryption__MasterKey="test-master-key-that-is-at-least-32-characters-long-for-security" \
+  -e HostValidation__AllowedHosts__0="localhost" \
+  -e HostValidation__AllowedHosts__1="127.0.0.1" \
   honuaio/honua-server:latest
 
 curl http://localhost:8080/healthz/ready</code></pre>
+            <p>
+              This is the local Docker evaluation path. For production deployments, use managed secrets,
+              a real encryption key, and an explicit host/base URL configuration.
+            </p>
+            <p>
+              If you bind a different host port, update the URLs in the next steps to match.
+            </p>
           </article>
           <article class="card" style="margin-top: 16px;">
             <p class="card-kicker">Step 2</p>
-            <h3>Make a first API call</h3>
-            <pre><code>curl "http://localhost:8080/rest/services/1/FeatureServer/0/query?where=1%3D1&amp;outFields=*&amp;f=json"</code></pre>
+            <h3>Set up auth for admin and automation calls</h3>
+            <p>
+              In this local Docker path, the initial admin API key is the same value you set in
+              <span class="inline-code">HONUA_ADMIN_PASSWORD</span>.
+            </p>
+            <pre><code>export HONUA_ADMIN_API_KEY="change-me-now"
+
+curl -H "X-API-Key: ${HONUA_ADMIN_API_KEY}" \
+  http://localhost:8080/api/v1/admin/capabilities</code></pre>
           </article>
           <article class="card" style="margin-top: 16px;">
             <p class="card-kicker">Step 3</p>
-            <h3>Install one SDK</h3>
-            <pre><code>npm install @honua/sdk-js</code></pre>
-            <pre><code>import { HonuaClient } from "@honua/sdk-js/honua";
-
-const client = new HonuaClient({ baseUrl: "https://your-honua-server.com" });
-const result = await client.queryFeatures({ serviceId: "parcels", layerId: 0 });</code></pre>
+            <h3>Make a first standards-compatible API call</h3>
+            <pre><code>curl "http://localhost:8080/rest/services?f=pjson"</code></pre>
+            <p>
+              A fresh server returns an empty service catalog. After you import or publish data,
+              this same endpoint becomes the GeoServices REST directory clients discover first.
+            </p>
           </article>
+          <article class="card" style="margin-top: 16px;">
+            <p class="card-kicker">Step 4</p>
+            <h3>Install one SDK</h3>
+            <p>The current MVP install path is the Python SDK directly from GitHub. It requires Python 3.11+.</p>
+            <pre><code>python3.11 -m venv .venv
+source .venv/bin/activate
+pip install "git+https://github.com/honua-io/honua-sdk-python.git@trunk"</code></pre>
+            <pre><code>python - &lt;&lt;'PY'
+from honua_sdk import HonuaClient
+
+with HonuaClient("http://localhost:8080") as client:
+    catalog = client.list_services(response_format="pjson")
+
+print(catalog.get("services", []))
+PY</code></pre>
+          </article>
+          <div class="callout">
+            This quickstart was validated against a clean Docker bring-up: fresh network, fresh PostGIS container,
+            explicit database readiness check, a server boot with the required local secrets and host allowlist,
+            one authenticated admin call, one public protocol call, and one SDK entry path.
+          </div>
         </section>
 
         <section class="section">
@@ -171,6 +212,29 @@ const result = await client.queryFeatures({ serviceId: "parcels", layerId: 0 });
           </div>
         </section>
       </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.google-analytics.com https://honua.io; form-action 'self' https://formsubmit.co; upgrade-insecure-requests"
     />
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V7YTZL98ML"></script>
     <script defer src="assets/analytics.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -432,6 +431,9 @@
           <div>
             <p class="footer-title">Trust</p>
             <a href="pricing.html">Pricing and Licensing</a>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
             <a href="docs.html">Docs and Quickstart</a>
             <a href="https://github.com/honua-io/honua-server" target="_blank" rel="noopener noreferrer">GitHub</a>
             <a href="mailto:security@honua.io">security@honua.io</a>

--- a/mobile.html
+++ b/mobile.html
@@ -10,6 +10,7 @@
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
   </head>
   <body>
     <div class="site-shell">
@@ -193,6 +194,29 @@
           </div>
         </section>
       </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/platform.html
+++ b/platform.html
@@ -10,6 +10,7 @@
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
   </head>
   <body>
     <div class="site-shell">
@@ -370,6 +371,29 @@
           </div>
         </section>
       </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/pricing.html
+++ b/pricing.html
@@ -10,6 +10,7 @@
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
   </head>
   <body>
     <div class="site-shell">
@@ -218,6 +219,29 @@
           </div>
         </section>
       </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua Privacy and Cookies</title>
+    <meta
+      name="description"
+      content="How honua.io handles contact form submissions, analytics consent, cookies, and limited site data."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Privacy</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="platform.html">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Privacy and Cookies</p>
+          <h1>Limited site data, explicit consent, and clear contact handling.</h1>
+          <p class="page-intro">
+            honua.io is a product and documentation site. We only collect the information needed to respond to inbound
+            contact requests and, if you consent, basic site analytics.
+          </p>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">What We Collect</p>
+            <h2>Only the data needed to run the site and answer inquiries.</h2>
+          </div>
+          <div class="note-grid">
+            <article class="note-card">
+              <h3>Contact form submissions</h3>
+              <p>Name, work email, company, and the message you submit through the site contact form.</p>
+            </article>
+            <article class="note-card">
+              <h3>Optional analytics</h3>
+              <p>Page-view and site-interaction analytics load only after you accept analytics cookies.</p>
+            </article>
+            <article class="note-card">
+              <h3>Basic server logs</h3>
+              <p>Standard hosting and security logs may capture IP address, browser details, and request metadata.</p>
+            </article>
+            <article class="note-card">
+              <h3>No account requirement</h3>
+              <p>You can read the site and public docs without creating an account or providing personal data.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">How We Use It</p>
+            <h2>Inquiry handling, site improvement, and security.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Data</th>
+                  <th>Purpose</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Contact form data</td>
+                  <td>Respond to questions, schedule follow-up, and handle early-access or commercial discussions.</td>
+                </tr>
+                <tr>
+                  <td>Consented analytics</td>
+                  <td>Understand which pages help or confuse buyers so the site can improve over time.</td>
+                </tr>
+                <tr>
+                  <td>Security and hosting logs</td>
+                  <td>Detect abuse, troubleshoot delivery issues, and keep the site available.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section id="cookies" class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Cookies</p>
+            <h2>Analytics only loads after consent.</h2>
+            <p class="section-copy">
+              The site shows a cookie banner before analytics loads. Accepting analytics enables Google Analytics for
+              this site. Declining keeps the site functional and skips analytics cookies.
+            </p>
+          </div>
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">Essential behavior</p>
+              <h2>No analytics before consent.</h2>
+              <p>
+                Honua does not load Google Analytics until you click <strong>Accept analytics</strong> in the cookie banner.
+              </p>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">Cookie control</p>
+              <h2>Reset the choice any time.</h2>
+              <p>
+                Use the button below to clear the current cookie preference and show the banner again.
+              </p>
+              <div class="action-row">
+                <button class="button button-secondary" type="button" data-cookie-reset>Reset Cookie Choice</button>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Retention and Sharing</p>
+            <h2>We keep inquiry data only as long as it remains useful.</h2>
+          </div>
+          <div class="note-grid">
+            <article class="note-card">
+              <h3>Retention</h3>
+              <p>Contact inquiries are retained for follow-up, commercial discussion, and basic relationship history.</p>
+            </article>
+            <article class="note-card">
+              <h3>Processors</h3>
+              <p>The site currently relies on FormSubmit for contact-form handling and Google Analytics only after consent.</p>
+            </article>
+            <article class="note-card">
+              <h3>No sale of personal data</h3>
+              <p>Honua does not sell contact data collected through the site.</p>
+            </article>
+            <article class="note-card">
+              <h3>Questions</h3>
+              <p>For site privacy questions, email <a class="text-link" href="mailto:mike@honua.io">mike@honua.io</a>.</p>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/protocols.html
+++ b/protocols.html
@@ -10,6 +10,7 @@
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
   </head>
   <body>
     <div class="site-shell">
@@ -269,6 +270,29 @@
           </div>
         </section>
       </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/sdks.html
+++ b/sdks.html
@@ -10,6 +10,7 @@
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
   </head>
   <body>
     <div class="site-shell">
@@ -38,7 +39,8 @@
           <p class="eyebrow">SDKs</p>
           <h1>Typed clients for JavaScript, .NET, Python, and AI agents.</h1>
           <p class="page-intro">
-            Install one SDK, make an authenticated call, and start building. All SDKs are Apache 2.0.
+            Python is the fastest public install path today. JavaScript and .NET repo guides are available
+            during early access while package publishing is finalized. All SDKs are Apache 2.0.
           </p>
         </section>
 
@@ -52,21 +54,37 @@
               <p class="card-kicker">JavaScript</p>
               <h3>Web apps and Esri migration</h3>
               <p>Typed clients, OGC helpers, Esri compatibility wrappers, migration scanners, codemods, and runtime parity matrices.</p>
-              <pre><code>npm install @honua/sdk-js</code></pre>
+              <p>
+                Early-access path: use the repo quickstart while public package publishing is finalized.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/honua-io/honua-sdk-js"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Open JS SDK repo</a
+              >
             </article>
             <article class="card">
               <p class="card-kicker">.NET</p>
               <h3>Enterprise services and MAUI</h3>
               <p>gRPC feature queries with streaming, admin API client, and geocoding. Natural path into MAUI mobile and the broader Microsoft stack.</p>
-              <pre><code>dotnet add package Honua.Sdk.Grpc --prerelease
-dotnet add package Honua.Sdk.Admin --prerelease</code></pre>
+              <p>
+                Early-access path: use the install guide for pre-release package feeds and source guidance.
+              </p>
+              <a
+                class="text-link"
+                href="https://github.com/honua-io/honua-sdk-dotnet/blob/trunk/INSTALL.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Open .NET install guide</a
+              >
             </article>
             <article class="card">
               <p class="card-kicker">Python</p>
               <h3>Data workflows and automation</h3>
               <p>Feature access, geocoding, admin automation, optional gRPC streaming, and GeoPandas integration for notebooks and pipelines.</p>
-              <pre><code>pip install honua-sdk
-pip install honua-sdk[grpc]</code></pre>
+              <pre><code>pip install "git+https://github.com/honua-io/honua-sdk-python.git@trunk"</code></pre>
             </article>
           </div>
         </section>
@@ -162,6 +180,29 @@ pip install honua-sdk[grpc]</code></pre>
           </div>
         </section>
       </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
     </div>
   </body>
 </html>

--- a/security.html
+++ b/security.html
@@ -1,0 +1,176 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua Security and DPA</title>
+    <meta
+      name="description"
+      content="Security contact, customer-managed deployment model, site controls, and DPA availability for Honua commercial engagements."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Security and DPA</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="platform.html">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Security and DPA</p>
+          <h1>Clear security contact, clear deployment boundary, clear data-processing posture.</h1>
+          <p class="page-intro">
+            Honua is primarily a customer-managed deployment model today. That changes the security and data-processing
+            posture: customers run the product in their own environment unless a separate commercial agreement states otherwise.
+          </p>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Security Contact</p>
+            <h2>Report security concerns directly.</h2>
+          </div>
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">Email</p>
+              <h2><a class="text-link" href="mailto:security@honua.io">security@honua.io</a></h2>
+              <p>Use this address for vulnerability reports, security questions, and responsible disclosure coordination.</p>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">Expectation</p>
+              <h2>Share enough detail to reproduce the issue.</h2>
+              <p>Include affected version, deployment shape, impact, and clear reproduction steps where possible.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Deployment Security Model</p>
+            <h2>Customer-managed by default.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Area</th>
+                  <th>Default posture</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Application runtime</td>
+                  <td>Honua provides the application, images, SDKs, and deployment guidance.</td>
+                </tr>
+                <tr>
+                  <td>Cloud account and network controls</td>
+                  <td>The customer owns cloud configuration, TLS, WAF, allowlists, backups, and infrastructure availability unless a separate agreement says otherwise.</td>
+                </tr>
+                <tr>
+                  <td>Admin authentication</td>
+                  <td>API key by default, optional OIDC bearer-token flow for browser-based admin access.</td>
+                </tr>
+                <tr>
+                  <td>Observability and hardening</td>
+                  <td>Honua publishes the controls and reference patterns, while the operator implements them in the target environment.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Data Processing Addendum</p>
+            <h2>DPA availability depends on the engagement model.</h2>
+          </div>
+          <div class="note-grid">
+            <article class="note-card">
+              <h3>Self-hosted deployments</h3>
+              <p>The customer generally controls the application environment and customer data, so Honua is not the default processor for workload data inside that deployment.</p>
+            </article>
+            <article class="note-card">
+              <h3>Commercial support or services</h3>
+              <p>If a commercial engagement requires Honua to process customer personal data, DPA terms can be provided as part of the contract package.</p>
+            </article>
+            <article class="note-card">
+              <h3>Managed or hosted offerings</h3>
+              <p>Any future managed-hosting relationship will carry its own specific data-processing terms and security commitments.</p>
+            </article>
+            <article class="note-card">
+              <h3>Site data</h3>
+              <p>This public website only handles contact-form submissions and optional analytics after cookie consent.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Public Security Posture</p>
+            <h2>What is already public.</h2>
+          </div>
+          <div class="note-grid">
+            <article class="note-card">
+              <h3>Security headers</h3>
+              <p>The site artifact ships with CSP and related security-header policy, and live edge enforcement is part of deployment validation.</p>
+            </article>
+            <article class="note-card">
+              <h3>Open documentation</h3>
+              <p>Deployment, procurement, and security posture are documented publicly so customers can evaluate the platform without custom decks.</p>
+            </article>
+            <article class="note-card">
+              <h3>License clarity</h3>
+              <p>The runtime, SDKs, mobile tooling, and private operator layer all have explicit license or availability boundaries.</p>
+            </article>
+            <article class="note-card">
+              <h3>Further questions</h3>
+              <p>Email <a class="text-link" href="mailto:mike@honua.io">mike@honua.io</a> for commercial DPA or procurement follow-up.</p>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -687,6 +687,40 @@ pre {
   line-height: 1.6;
 }
 
+.cookie-banner {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 40;
+  width: min(460px, calc(100% - 40px));
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border: 1px solid rgba(19, 37, 47, 0.12);
+  border-radius: 24px;
+  background: rgba(255, 250, 242, 0.96);
+  box-shadow: 0 18px 40px rgba(19, 37, 47, 0.18);
+  backdrop-filter: blur(18px);
+}
+
+.cookie-banner-copy strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 1rem;
+}
+
+.cookie-banner-copy p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.cookie-banner-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
 .contact-grid {
   grid-template-columns: minmax(0, 1fr) minmax(320px, 0.96fr);
 }
@@ -865,5 +899,11 @@ pre {
   .mini-grid,
   .note-grid {
     grid-template-columns: 1fr;
+  }
+
+  .cookie-banner {
+    right: 10px;
+    bottom: 10px;
+    width: calc(100% - 20px);
   }
 }

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,143 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua Terms of Use</title>
+    <meta
+      name="description"
+      content="Terms for using honua.io, contacting Honua through the site, and relying on public product information."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Terms</span>
+          </div>
+        </a>
+        <nav class="nav-links" aria-label="Primary">
+          <a href="index.html">Home</a>
+          <a href="platform.html">Platform</a>
+          <a href="protocols.html">Protocols</a>
+          <a href="sdks.html">SDKs</a>
+          <a href="mobile.html">Mobile</a>
+          <a href="pricing.html">Pricing</a>
+          <a href="docs.html">Docs</a>
+          <a class="button button-nav" href="index.html#contact">Talk to Us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Terms of Use</p>
+          <h1>Use the site responsibly and treat public information as informational unless contracted otherwise.</h1>
+          <p class="page-intro">
+            These terms apply to honua.io and the public site content. Product licenses, support terms, and commercial
+            commitments are governed by the relevant repository license or signed commercial agreement.
+          </p>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Site Use</p>
+            <h2>What you can expect from the public site.</h2>
+          </div>
+          <div class="note-grid">
+            <article class="note-card">
+              <h3>Informational content</h3>
+              <p>The site is intended to explain the product, provide quickstarts, and support evaluation conversations.</p>
+            </article>
+            <article class="note-card">
+              <h3>No production guarantee</h3>
+              <p>Public site content is not itself a warranty, SLA, or binding support commitment.</p>
+            </article>
+            <article class="note-card">
+              <h3>Repository licenses still control</h3>
+              <p>Open-source and source-available code remains governed by the applicable repository license, not by this page.</p>
+            </article>
+            <article class="note-card">
+              <h3>Commercial terms are separate</h3>
+              <p>Pricing, support, DPA, and enterprise commitments become binding only when included in an executed agreement.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Acceptable Use</p>
+            <h2>Do not abuse the site or contact channel.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Allowed</th>
+                  <th>Not allowed</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Read public content, evaluate the product, and submit legitimate questions through the contact form.</td>
+                  <td>Attempting to disrupt the site, spam the contact form, scrape abusive volumes, or use the site to deliver harmful content.</td>
+                </tr>
+                <tr>
+                  <td>Reuse public site content internally under the published site license.</td>
+                  <td>Misrepresenting Honua's public content as a binding commercial commitment when no agreement exists.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="detail-grid">
+            <article class="detail-card">
+              <p class="eyebrow">Contact</p>
+              <h2>Submitting the contact form</h2>
+              <p>
+                By sending the contact form, you authorize Honua to respond to your inquiry using the information you provide.
+              </p>
+            </article>
+            <article class="detail-card">
+              <p class="eyebrow">Changes</p>
+              <h2>Terms may evolve as the launch matures.</h2>
+              <p>
+                Honua may update these site terms as the product and commercial model evolve. Material updates will be published here.
+              </p>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">Cloud-native geospatial platform for migration, apps, field work, and agents.</p>
+          </div>
+          <div>
+            <p class="footer-title">Explore</p>
+            <a href="platform.html">Platform</a>
+            <a href="protocols.html">Protocols</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Mobile</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+            <a href="security.html">Security and DPA</a>
+            <a href="mailto:security@honua.io">security@honua.io</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Closes #4
Closes #6

## Summary
- add Privacy, Terms, and Security/DPA pages
- gate analytics behind explicit cookie consent and add reset controls
- add trust links across the site footer
- replace the broken quickstart commands with a Docker path validated against a clean PostGIS + Honua bring-up
- switch the SDK quickstart to the currently working Python source-install path and correct the SDK page so it no longer points at unpublished package-manager installs
- refresh the site README for the current repo layout and validation scripts

## Validation
- `./scripts/build-dist.sh`
- `./scripts/validate-workflow-pinning.sh`
- artifact check for `dist/privacy.html`, `dist/terms.html`, `dist/security.html`, and updated `dist/docs.html` content
- clean-environment smoke run:
  - start PostGIS in Docker
  - start `honuaio/honua-server:latest` with the required admin password, encryption key, and host allowlist
  - `curl -H "X-API-Key: ..." http://localhost:18080/api/v1/admin/capabilities`
  - `curl http://localhost:18080/rest/services?f=pjson`
  - `pip install "git+https://github.com/honua-io/honua-sdk-python.git@trunk"` in a fresh Python 3.11 venv
  - `HonuaClient.list_services(response_format="pjson")` against the running server

## Note
- the repo-local artifact/header checks are green
- the optional live-header probe against current `https://honua.io` still reports missing CSP frame-ancestors enforcement at the edge, so the security page copy was kept accurate and does not overclaim the live header posture
