### PR TITLE
feat: Preview release claims matrix for source-backed public messaging (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ Repository layout:
 - `mobile.html` - mobile and field workflow page
 - `pricing.html` - pricing and licensing page
 - `docs.html` - quickstart and docs hub
+- `claims.html` - public claims matrix for Preview/Beta/proof/deferred status review
 - `privacy.html` - privacy and cookie notice
 - `terms.html` - site terms of use
 - `security.html` - security contact and DPA posture
 - `styles.css` - site styles
-- `assets/` - static assets
+- `assets/` - static assets, navigation JavaScript, and consent-gated analytics/CTA attribution
 - `_headers` - deployment response headers (CSP, clickjacking, and related security headers)
 - `scripts/build-dist.sh` - build the deployable static artifact
 - `scripts/validate-security-headers.sh` - validate live security headers when a target URL is configured

--- a/agentic-gis.html
+++ b/agentic-gis.html
@@ -60,10 +60,11 @@
             <p class="eyebrow">AI Agents</p>
             <h1>Let AI workflows work with spatial context directly.</h1>
             <p class="lede">
-              Honua exposes every collection, schema, spatial operation, and topology tool through the
+              Honua exposes discovery, schema inspection, filtered queries, statistics where supported,
+              and bounded spatial tools through the
               <a class="text-link" href="https://modelcontextprotocol.io" target="_blank" rel="noopener noreferrer">Model Context Protocol (MCP)</a>.
               Claude, GPT, Cursor, or your own agent discovers what exists, inspects the schema, and runs
-              typed queries — no scraping, no hand-written wrappers.
+              typed queries in Preview without scraping or hand-written wrappers.
             </p>
             <div class="action-row">
               <a class="button button-primary" href="docs.html">Read the docs</a>
@@ -74,7 +75,7 @@
               <span class="proof-pill">Discoverable collections</span>
               <span class="proof-pill">Schema inspection</span>
               <span class="proof-pill">Filtered queries</span>
-              <span class="proof-pill">Topology-aware tools</span>
+              <span class="proof-pill">Bounded spatial tools</span>
             </div>
           </div>
           <div class="artifact-grid">
@@ -105,7 +106,7 @@ input:
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">What the MCP surface covers</p>
-            <h2>Three capabilities every agent needs to work with spatial data.</h2>
+            <h2>Three Preview capabilities agents need to work with spatial data.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
@@ -125,10 +126,10 @@ input:
             </article>
             <article class="card">
               <p class="card-kicker">Operations</p>
-              <h3>Run filtered queries, spatial predicates, and topology checks.</h3>
+              <h3>Run filtered queries and bounded spatial predicates.</h3>
               <p>
-                First-class tools for buffer, overlap, contains, crosses, and within — not raw REST calls
-                the agent has to compose.
+                Preview tools cover bounded operations such as buffer, overlap, contains, crosses, and within
+                where the underlying service enables them.
               </p>
             </article>
           </div>
@@ -156,8 +157,8 @@ input:
               <p class="card-kicker">With MCP</p>
               <h3>Agents discover, inspect, then act.</h3>
               <p>
-                Every tool call is typed. Every schema is introspectable. Every spatial operation has a
-                defined contract. The agent adapts when the data changes — without rewriting prompts.
+                Tool calls are typed where the schema covers them. Schemas are introspectable, and supported
+                spatial operations have defined contracts. The agent can adapt when the data changes.
               </p>
             </article>
           </div>
@@ -190,12 +191,12 @@ input:
               <h3>LLM workflows that touch real spatial state.</h3>
               <p>
                 Route tasks from internal copilots into governed spatial tools without exposing raw APIs
-                to every workflow author.
+                to each workflow author.
               </p>
             </article>
           </div>
           <div class="callout">
-            Anything an analyst could do in a SQL client or a QGIS session, the agent can do over MCP.
+            Common analyst discovery, query, and bounded spatial tasks can be evaluated over MCP in Preview.
           </div>
         </section>
 
@@ -203,8 +204,8 @@ input:
           <p class="eyebrow">Next</p>
           <h2>Plug it into your agent.</h2>
           <p>
-            Read the MCP schema, wire it into Claude, Cursor, or your own agent framework, and point it
-            at a Honua instance.
+            Read the MCP schema, wire it into Claude, Cursor, or your own agent framework, and evaluate it
+            against a Honua instance.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="docs.html">Open docs</a>
@@ -220,7 +221,7 @@ input:
             <p class="eyebrow">Build the next layer</p>
             <h2>A spatial interface agents can actually use.</h2>
             <p class="footer-copy">
-              Discovery, schema, and typed operations in one protocol. Works with every MCP-aware agent — and the spec is open.
+              Discovery, schema, and typed operations in one protocol. Works with MCP-aware agent clients, and the spec is open.
             </p>
           </div>
           <div class="footer-actions">
@@ -252,6 +253,7 @@ input:
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -6,6 +6,19 @@
   const analyticsId = "G-V7YTZL98ML";
   const attributionKey = "honua_lead_attribution";
   const utmFields = ["source", "medium", "campaign", "term", "content"];
+  const leadAttributionFields = [
+    "lead_landing_page",
+    "lead_current_page",
+    "lead_referrer",
+    "lead_utm_source",
+    "lead_utm_medium",
+    "lead_utm_campaign",
+    "lead_utm_term",
+    "lead_utm_content",
+    "lead_cta_label",
+    "lead_cta_page",
+    "lead_cta_href"
+  ];
   let analyticsLoaded = false;
   let currentConsent = null;
 
@@ -32,6 +45,8 @@
     } catch {
       // Ignore storage failures and keep the site usable.
     }
+    clearAttribution();
+    clearContactAttributionFields();
     setAnalyticsEnabled(false);
   }
 
@@ -51,13 +66,27 @@
     }
   }
 
+  function clearAttribution() {
+    try {
+      window.sessionStorage.removeItem(attributionKey);
+    } catch {
+      // Ignore storage failures and keep the site usable.
+    }
+  }
+
   function currentPage() {
     return window.location.href;
   }
 
   function readUtmParams() {
     const values = {};
-    const params = new URLSearchParams(window.location.search);
+    let params;
+
+    try {
+      params = new URLSearchParams(window.location.search);
+    } catch {
+      return values;
+    }
 
     utmFields.forEach(function (field) {
       const value = params.get("utm_" + field);
@@ -70,6 +99,10 @@
   }
 
   function initAttribution() {
+    if (!hasAnalyticsConsent()) {
+      return {};
+    }
+
     const existing = readAttribution();
     const next = Object.assign({}, existing);
 
@@ -167,6 +200,10 @@
   }
 
   function rememberCta(link) {
+    if (!hasAnalyticsConsent()) {
+      return {};
+    }
+
     const next = Object.assign({}, readAttribution(), {
       cta_label: ctaLabel(link),
       cta_page: currentPage(),
@@ -191,9 +228,9 @@
         const attribution = rememberCta(link);
         sendAnalyticsEvent(link.dataset.analyticsEvent || "cta_click", {
           event_category: "conversion",
-          event_label: attribution.cta_label,
-          destination: attribution.cta_href,
-          page_location: attribution.cta_page
+          event_label: attribution.cta_label || ctaLabel(link),
+          destination: attribution.cta_href || ctaDestination(link),
+          page_location: attribution.cta_page || currentPage()
         });
       });
     });
@@ -206,8 +243,27 @@
     }
   }
 
+  function clearContactAttribution(form) {
+    leadAttributionFields.forEach(function (fieldName) {
+      setField(form, fieldName, "");
+    });
+  }
+
+  function clearContactAttributionFields() {
+    document.querySelectorAll("form[data-contact-form], form.contact-form").forEach(clearContactAttribution);
+  }
+
+  function populateContactAttributionFields() {
+    document.querySelectorAll("form[data-contact-form], form.contact-form").forEach(populateContactAttribution);
+  }
+
   function populateContactAttribution(form) {
-    const attribution = readAttribution();
+    if (!hasAnalyticsConsent()) {
+      clearContactAttribution(form);
+      return {};
+    }
+
+    const attribution = initAttribution();
     const utmParams = readUtmParams();
 
     setField(form, "lead_landing_page", attribution.landing_page || currentPage());
@@ -220,6 +276,7 @@
     setField(form, "lead_cta_label", attribution.cta_label || "");
     setField(form, "lead_cta_page", attribution.cta_page || "");
     setField(form, "lead_cta_href", attribution.cta_href || "");
+    return attribution;
   }
 
   function bindContactForms() {
@@ -252,8 +309,12 @@
     currentConsent = value;
     writeConsent(value);
     if (value === accepted) {
+      initAttribution();
+      populateContactAttributionFields();
       loadAnalytics();
     } else {
+      clearAttribution();
+      clearContactAttributionFields();
       setAnalyticsEnabled(false);
     }
     removeBanner();
@@ -301,12 +362,12 @@
   }
 
   function init() {
-    initAttribution();
-
     currentConsent = readConsent();
     if (currentConsent === accepted) {
+      initAttribution();
       loadAnalytics();
     } else {
+      clearAttribution();
       setAnalyticsEnabled(false);
     }
 

--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -7,6 +7,7 @@
   const attributionKey = "honua_lead_attribution";
   const utmFields = ["source", "medium", "campaign", "term", "content"];
   let analyticsLoaded = false;
+  let currentConsent = null;
 
   function readConsent() {
     try {
@@ -25,11 +26,13 @@
   }
 
   function clearConsent() {
+    currentConsent = null;
     try {
       window.localStorage.removeItem(consentKey);
     } catch {
       // Ignore storage failures and keep the site usable.
     }
+    setAnalyticsEnabled(false);
   }
 
   function readAttribution() {
@@ -95,7 +98,21 @@
     window.dataLayer.push(arguments);
   }
 
+  function hasAnalyticsConsent() {
+    return currentConsent === accepted;
+  }
+
+  function setAnalyticsEnabled(enabled) {
+    window["ga-disable-" + analyticsId] = !enabled;
+  }
+
   function loadAnalytics() {
+    if (!hasAnalyticsConsent()) {
+      return;
+    }
+
+    setAnalyticsEnabled(true);
+
     if (analyticsLoaded) {
       return;
     }
@@ -113,7 +130,7 @@
   }
 
   function sendAnalyticsEvent(eventName, params) {
-    if (readConsent() !== accepted) {
+    if (!hasAnalyticsConsent()) {
       return;
     }
 
@@ -121,8 +138,14 @@
       loadAnalytics();
     }
 
-    if (typeof window.gtag === "function") {
+    if (!analyticsLoaded || typeof window.gtag !== "function") {
+      return;
+    }
+
+    try {
       window.gtag("event", eventName, params);
+    } catch {
+      // Analytics must never block navigation, form submission, or site controls.
     }
   }
 
@@ -200,9 +223,12 @@
       populateContactAttribution(form);
       form.addEventListener("submit", function () {
         populateContactAttribution(form);
-        sendAnalyticsEvent("contact_submit", {
+        sendAnalyticsEvent(form.dataset.analyticsEvent || "lead_form_submit", {
           event_category: "conversion",
-          event_label: form.elements.lead_cta_label ? form.elements.lead_cta_label.value || "contact_form" : "contact_form",
+          event_label:
+            form.dataset.analyticsLabel ||
+            (form.elements.lead_cta_label ? form.elements.lead_cta_label.value || "contact_form" : "contact_form"),
+          destination: form.dataset.analyticsDestination || "formsubmit",
           lead_current_page: currentPage(),
           transport_type: "beacon"
         });
@@ -218,15 +244,18 @@
   }
 
   function setConsent(value) {
+    currentConsent = value;
     writeConsent(value);
     if (value === accepted) {
       loadAnalytics();
+    } else {
+      setAnalyticsEnabled(false);
     }
     removeBanner();
   }
 
   function renderBanner() {
-    const consent = readConsent();
+    const consent = currentConsent;
     if (consent === accepted || consent === declined || !document.body || document.getElementById(bannerId)) {
       return;
     }
@@ -269,8 +298,11 @@
   function init() {
     initAttribution();
 
-    if (readConsent() === accepted) {
+    currentConsent = readConsent();
+    if (currentConsent === accepted) {
       loadAnalytics();
+    } else {
+      setAnalyticsEnabled(false);
     }
 
     renderBanner();

--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -154,12 +154,16 @@
       return link.dataset.analyticsLabel;
     }
 
+    if (link.dataset.ctaLocation) {
+      return link.dataset.ctaLocation;
+    }
+
     const text = link.textContent.trim().toLowerCase().replace(/\s+/g, "_");
     return text || "site_cta";
   }
 
   function ctaDestination(link) {
-    return link.dataset.analyticsDestination || link.getAttribute("href") || link.href || "";
+    return link.dataset.analyticsDestination || link.dataset.ctaDestination || link.getAttribute("href") || link.href || "";
   }
 
   function rememberCta(link) {
@@ -227,8 +231,9 @@
           event_category: "conversion",
           event_label:
             form.dataset.analyticsLabel ||
+            form.dataset.ctaLocation ||
             (form.elements.lead_cta_label ? form.elements.lead_cta_label.value || "contact_form" : "contact_form"),
-          destination: form.dataset.analyticsDestination || "formsubmit",
+          destination: form.dataset.analyticsDestination || form.dataset.ctaDestination || "formsubmit",
           lead_current_page: currentPage(),
           transport_type: "beacon"
         });

--- a/claims.html
+++ b/claims.html
@@ -1,0 +1,464 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua | Public Claims Matrix</title>
+    <meta
+      name="description"
+      content="Preview release claims matrix mapping Honua public messaging to source-backed evidence, proof assets, owner tickets, roadmap labels, or deferred status."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell">
+      <header class="topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">One foundation · Every user</span>
+          </div>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+        <nav class="nav-groups" aria-label="Primary">
+          <div class="nav-group">
+            <a class="nav-group-title" href="platform.html">Platform</a>
+            <div class="nav-subnav">
+              <a href="agentic-gis.html">AI Agents</a>
+              <a href="runtime.html">gRPC Runtime</a>
+              <a href="devops.html">GitOps + OTel</a>
+            </div>
+          </div>
+          <div class="nav-group">
+            <a class="nav-group-title" href="docs.html">Developers</a>
+            <div class="nav-subnav">
+              <a href="docs.html">Docs</a>
+              <a href="sdks.html">SDKs</a>
+              <a href="mobile.html">Field Toolkit</a>
+            </div>
+          </div>
+          <div class="nav-group">
+            <a class="nav-group-title" href="protocols.html">Compatibility</a>
+            <div class="nav-subnav">
+              <a href="protocols.html">Standards &amp; Conformance</a>
+              <a href="modernization.html#arcgis-geoserver">ArcGIS + GeoServer</a>
+            </div>
+          </div>
+          <a class="nav-utility" href="modernization.html">Modernize</a>
+          <a class="nav-utility" href="pricing.html">Open Core</a>
+          <a class="nav-utility" href="https://github.com/honua-io/honua-server" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a
+            class="button button-nav"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-cta-location="claims-nav"
+            data-cta-destination="contact"
+          >Talk to us</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Public claims matrix</p>
+          <h1>Preview claims stay tied to evidence.</h1>
+          <p class="page-intro">
+            This matrix is the site-owned review surface for public Preview messaging. Each major claim
+            category maps to shipped source evidence, preview proof, an owner ticket, a roadmap/Beta label,
+            or an explicit deferred status before broad outreach.
+          </p>
+          <div class="action-row">
+            <a
+              class="button button-primary"
+              href="https://github.com/honua-io/honua-sales/blob/trunk/docs/strategy/GTM_ROADMAP_PROJECT.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-analytics-event="cta_click"
+              data-cta-location="claims-hero"
+              data-cta-destination="gtm-roadmap-source"
+            >GTM roadmap source</a>
+            <a
+              class="button button-secondary"
+              href="https://github.com/orgs/honua-io/projects/2"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-analytics-event="cta_click"
+              data-cta-location="claims-hero"
+              data-cta-destination="roadmap-project"
+            >Roadmap Project</a>
+            <a
+              class="button button-ghost"
+              href="docs.html"
+              data-analytics-event="cta_click"
+              data-cta-location="claims-hero"
+              data-cta-destination="docs"
+            >Docs</a>
+          </div>
+          <p class="page-intro">
+            Source path tracked by the release lane:
+            <code class="inline-code">honua-sales/docs/strategy/GTM_ROADMAP_PROJECT.md</code>.
+            If that document is private or unpublished, the owner gap remains with
+            <a class="text-link" href="https://github.com/honua-io/honua-sales/issues/4" target="_blank" rel="noopener noreferrer">honua-sales#4</a>.
+          </p>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Status vocabulary</p>
+            <h2>Review terms used in the matrix.</h2>
+          </div>
+          <div class="note-grid">
+            <article class="note-card">
+              <span class="status-tag status-source">Source-backed</span>
+              <p>Claim can be stated as Preview-current when linked evidence supports the exact scope.</p>
+            </article>
+            <article class="note-card">
+              <span class="status-tag status-preview">Preview partial</span>
+              <p>Claim can be marketed for evaluation, but partial parity and caveats must stay visible.</p>
+            </article>
+            <article class="note-card">
+              <span class="status-tag status-pending">Proof pending</span>
+              <p>Claim may be described as a Preview target, not as validated or generally available.</p>
+            </article>
+            <article class="note-card">
+              <span class="status-tag status-beta">Roadmap / Beta</span>
+              <p>Claim belongs to Beta, named pilot, or later roadmap scope.</p>
+            </article>
+            <article class="note-card">
+              <span class="status-tag status-deferred">Deferred</span>
+              <p>Claim must not be marketed as Preview-ready.</p>
+            </article>
+            <article class="note-card">
+              <span class="status-tag status-external">External owner</span>
+              <p>Release gap belongs to another repo; this site only links the owner ticket or source.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Claims by area</p>
+            <h2>Major public claims and allowed Preview framing.</h2>
+            <p class="section-copy">
+              The public pages can stay forceful where the evidence is exact. Anything proof-pending,
+              Beta, externally owned, or deferred needs the softer wording rule shown here.
+            </p>
+          </div>
+          <div class="table-wrap">
+            <table class="claims-table">
+              <thead>
+                <tr>
+                  <th>Claim area</th>
+                  <th>Public pages</th>
+                  <th>Public wording rule</th>
+                  <th>Status</th>
+                  <th>Evidence or owner</th>
+                  <th>Review notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr id="runtime-platform">
+                  <td data-label="Claim area"><strong>Runtime and single-binary platform</strong></td>
+                  <td data-label="Public pages">Home, Platform, Runtime, Protocols, Docs</td>
+                  <td data-label="Public wording rule">Say the documented compatibility and gRPC surfaces run from one runtime. Do not imply every roadmap capability is GA.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-source">Source-backed</span>
+                    <span class="status-tag status-preview">Preview partial</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/PLATFORM.md" target="_blank" rel="noopener noreferrer">honua-server PLATFORM.md</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/MVP_COMPATIBILITY_CONTRACT.md" target="_blank" rel="noopener noreferrer">MVP compatibility contract</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/issues/876" target="_blank" rel="noopener noreferrer">honua-server#876</a>
+                  </td>
+                  <td data-label="Review notes">Keep same-runtime claims scoped to server-owned surfaces documented in source.</td>
+                </tr>
+                <tr id="ogc-standards">
+                  <td data-label="Claim area"><strong>OGC and standards conformance counts</strong></td>
+                  <td data-label="Public pages">Home, Platform, Protocols</td>
+                  <td data-label="Public wording rule">Use exact counts only where source evidence says the same. WFS must be partial parity unless a specific CITE proof is linked.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-source">Source-backed</span>
+                    <span class="status-tag status-preview">Preview partial</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/MVP_COMPATIBILITY_CONTRACT.md" target="_blank" rel="noopener noreferrer">MVP compatibility contract</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/data/public-interface-proof.json" target="_blank" rel="noopener noreferrer">public interface proof ledger</a>
+                  </td>
+                  <td data-label="Review notes">Allowed exact counts: OGC API Features 137/137, Tiles 16/16, Maps 32/32, WMS 227/227, WMTS 118/118.</td>
+                </tr>
+                <tr id="geoservices-compat">
+                  <td data-label="Claim area"><strong>GeoServices, ArcGIS, and GeoServer compatibility</strong></td>
+                  <td data-label="Public pages">Home, Platform, Protocols, Modernization</td>
+                  <td data-label="Public wording rule">Say supported with partial parity. Preserve gaps for FeatureServer, MapServer, ImageServer, Geometry Service, and GPServer.</td>
+                  <td data-label="Status"><span class="status-tag status-preview">Preview partial</span></td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/geoservices-rest-parity.md" target="_blank" rel="noopener noreferrer">GeoServices parity doc</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/data/geoservices-rest-parity.json" target="_blank" rel="noopener noreferrer">parity data</a>
+                  </td>
+                  <td data-label="Review notes">Avoid "clients keep working" or backend-swap absolutes without a parity run for the target estate.</td>
+                </tr>
+                <tr id="migration-cutover">
+                  <td data-label="Claim area"><strong>Migration wedge and cutover automation</strong></td>
+                  <td data-label="Public pages">Home, Modernization, SDKs, Docs, Pricing</td>
+                  <td data-label="Public wording rule">Frame import, parity, reconciliation, and cutover as pilot-scoped or proof-pending until migration evidence is linked.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-pending">Proof pending</span>
+                    <span class="status-tag status-external">External owner</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    Release manifest <code class="inline-code">release/honua-2026-05-preview.json</code>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/issues/646" target="_blank" rel="noopener noreferrer">honua-server#646</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/issues/878" target="_blank" rel="noopener noreferrer">#878</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/issues/879" target="_blank" rel="noopener noreferrer">#879</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/issues/880" target="_blank" rel="noopener noreferrer">#880</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sdk-js/issues/59" target="_blank" rel="noopener noreferrer">honua-sdk-js#59</a>
+                  </td>
+                  <td data-label="Review notes">No "nothing recreated by hand," "clients keep working," or unconditional "cut over when ready" claims.</td>
+                </tr>
+                <tr id="grpc-sdks">
+                  <td data-label="Claim area"><strong>gRPC and SDKs</strong></td>
+                  <td data-label="Public pages">Home, Platform, Runtime, SDKs, Docs, Pricing</td>
+                  <td data-label="Public wording rule">Describe typed protocol and SDK examples as Preview/alpha-aware. Do not imply all SDK families ship stable production packages.</td>
+                  <td data-label="Status"><span class="status-tag status-preview">Preview partial</span></td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/developer/SDK_COMPATIBILITY_MATRIX.md" target="_blank" rel="noopener noreferrer">SDK compatibility matrix</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sdk-js/issues/70" target="_blank" rel="noopener noreferrer">honua-sdk-js#70</a>
+                  </td>
+                  <td data-label="Review notes">Examples are illustrative unless package evidence confirms the exact import names and release channel.</td>
+                </tr>
+                <tr id="mcp-ai">
+                  <td data-label="Claim area"><strong>MCP and AI agent surface</strong></td>
+                  <td data-label="Public pages">Home, Platform, Agentic GIS, Runtime, Protocols, SDKs</td>
+                  <td data-label="Public wording rule">Limit claims to discovery/listing, schema inspection, filtered queries/statistics where supported, and bounded spatial tools.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-preview">Preview partial</span>
+                    <span class="status-tag status-pending">Proof pending</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/contributor/mcp-certification.md" target="_blank" rel="noopener noreferrer">MCP certification doc</a>,
+                    <a class="text-link" href="https://github.com/honua-io/geospatial-mcp" target="_blank" rel="noopener noreferrer">geospatial-mcp</a>
+                  </td>
+                  <td data-label="Review notes">Do not claim completed certification or every topology operation until an artifact is linked.</td>
+                </tr>
+                <tr id="mobile-field">
+                  <td data-label="Claim area"><strong>Mobile, field, offline, and MAUI</strong></td>
+                  <td data-label="Public pages">Home, Platform, SDKs, Field Toolkit, Docs, Pricing</td>
+                  <td data-label="Public wording rule">Label as Beta or pilot-scoped. Do not present offline sync, conflict handling, or device workflows as Preview-ready.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-beta">Roadmap / Beta</span>
+                    <span class="status-tag status-deferred">Deferred</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-mobile" target="_blank" rel="noopener noreferrer">honua-mobile owner repo</a>,
+                    release manifest deferred scope
+                  </td>
+                  <td data-label="Review notes">Keep mobile page language as Beta/pilot scope until field proof assets are attached.</td>
+                </tr>
+                <tr id="deployment-devops">
+                  <td data-label="Claim area"><strong>Deployment, GitOps, Terraform, Helm, OpenTelemetry</strong></td>
+                  <td data-label="Public pages">Home, Platform, DevOps, Pricing, Docs</td>
+                  <td data-label="Public wording rule">Say tracked or targeted deployment paths. Reserve "validated" for targets with linked validation evidence.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-pending">Proof pending</span>
+                    <span class="status-tag status-external">External owner</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/PLATFORM.md" target="_blank" rel="noopener noreferrer">honua-server PLATFORM.md</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-helm/issues/1" target="_blank" rel="noopener noreferrer">honua-helm#1</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-helm/issues/2" target="_blank" rel="noopener noreferrer">#2</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-helm/issues/6" target="_blank" rel="noopener noreferrer">#6</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-terraform/issues/1" target="_blank" rel="noopener noreferrer">honua-terraform#1</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-terraform/issues/2" target="_blank" rel="noopener noreferrer">#2</a>
+                  </td>
+                  <td data-label="Review notes">Terraform/Helm validation remains owned outside this site.</td>
+                </tr>
+                <tr id="pricing-support">
+                  <td data-label="Claim area"><strong>Pricing, pilot packaging, support, SLA, DPA, enterprise commitments</strong></td>
+                  <td data-label="Public pages">Pricing, Security, Terms, Home</td>
+                  <td data-label="Public wording rule">Keep support, SLA, DPA, enterprise, and pilot packaging as commercial conversation or owner-ticket-gated wording.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-external">External owner</span>
+                    <span class="status-tag status-beta">Roadmap / Beta</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="terms.html">Terms</a>,
+                    <a class="text-link" href="security.html">Security</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sales/issues/5" target="_blank" rel="noopener noreferrer">honua-sales#5</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sales/issues/6" target="_blank" rel="noopener noreferrer">#6</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-support/issues/7" target="_blank" rel="noopener noreferrer">honua-support#7</a>
+                  </td>
+                  <td data-label="Review notes">Public site content is not a warranty, SLA, support commitment, or pricing commitment.</td>
+                </tr>
+                <tr id="marketplace-buyer-path">
+                  <td data-label="Claim area"><strong>Marketplace and private-offer buyer path</strong></td>
+                  <td data-label="Public pages">Home, Pricing, future proof pages</td>
+                  <td data-label="Public wording rule">Do not add marketplace destination CTAs until owner tickets provide URLs, offer identifiers, and activation evidence.</td>
+                  <td data-label="Status"><span class="status-tag status-external">External owner</span></td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-marketplace/issues/3" target="_blank" rel="noopener noreferrer">honua-marketplace#3</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-marketplace/issues/5" target="_blank" rel="noopener noreferrer">#5</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sales/issues/42" target="_blank" rel="noopener noreferrer">honua-sales#42</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/issues/338" target="_blank" rel="noopener noreferrer">honua-server#338</a>
+                  </td>
+                  <td data-label="Review notes">This site only instruments existing CTAs and lead submission until marketplace handoff evidence exists.</td>
+                </tr>
+                <tr id="proof-hub">
+                  <td data-label="Claim area"><strong>Proof hub, benchmarks, compatibility matrix, reference architecture, showcase</strong></td>
+                  <td data-label="Public pages">Pricing, Protocols, future proof pages</td>
+                  <td data-label="Public wording rule">Describe proof assets as pending unless the public artifact exists and is linked.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-pending">Proof pending</span>
+                    <span class="status-tag status-external">External owner</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-site/issues/9" target="_blank" rel="noopener noreferrer">honua-site#9</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sales/issues/18" target="_blank" rel="noopener noreferrer">honua-sales#18</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sales/issues/25" target="_blank" rel="noopener noreferrer">#25</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sdk-js/issues/70" target="_blank" rel="noopener noreferrer">honua-sdk-js#70</a>
+                  </td>
+                  <td data-label="Review notes">Public benchmark claims stay proof-pending until benchmark outputs are published.</td>
+                </tr>
+                <tr id="narrow-3d-proof">
+                  <td data-label="Claim area"><strong>Narrow 3D construction-scene proof</strong></td>
+                  <td data-label="Public pages">Future proof hub or this matrix only</td>
+                  <td data-label="Public wording rule">Mention only the narrow proof slice when proof assets exist. Broad 3D platform, point-cloud, OpenUSD, Unreal, mobile AR, and visualization claims remain deferred.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-deferred">Deferred</span>
+                    <span class="status-tag status-source">Source-backed</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/issues/898" target="_blank" rel="noopener noreferrer">honua-server#898</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-server/issues/899" target="_blank" rel="noopener noreferrer">#899</a>
+                  </td>
+                  <td data-label="Review notes">No current public page should market broad 3D as Preview-ready.</td>
+                </tr>
+                <tr id="open-core">
+                  <td data-label="Claim area"><strong>Open core, repo availability, and no seats</strong></td>
+                  <td data-label="Public pages">Pricing, Terms, Security</td>
+                  <td data-label="Public wording rule">Link public repos for source availability. Frame "no seat pricing" as current commercial posture, not a permanent pricing commitment.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-source">Source-backed</span>
+                    <span class="status-tag status-external">External owner</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">Honua GitHub org</a>,
+                    <a class="text-link" href="terms.html">Terms</a>,
+                    <a class="text-link" href="pricing.html">Pricing page</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sales/issues/5" target="_blank" rel="noopener noreferrer">honua-sales#5</a>
+                  </td>
+                  <td data-label="Review notes">Commercial packaging remains sales-owned.</td>
+                </tr>
+                <tr id="site-cta-attribution">
+                  <td data-label="Claim area"><strong>Site CTA and lead attribution</strong></td>
+                  <td data-label="Public pages">Home contact form, page CTAs, footer CTAs</td>
+                  <td data-label="Public wording rule">The site may claim a scoped inbound conversation path. Marketplace handoff and CRM acceptance remain owner-ticket gated.</td>
+                  <td data-label="Status">
+                    <span class="status-tag status-source">Source-backed</span>
+                    <span class="status-tag status-external">External owner</span>
+                  </td>
+                  <td data-label="Evidence or owner">
+                    <a class="text-link" href="index.html#contact">Contact form</a>,
+                    <a class="text-link" href="assets/analytics.js">consented CTA analytics</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-site/issues/3" target="_blank" rel="noopener noreferrer">honua-site#3</a>,
+                    <a class="text-link" href="https://github.com/honua-io/honua-sales/issues/42" target="_blank" rel="noopener noreferrer">honua-sales#42</a>
+                  </td>
+                  <td data-label="Review notes">Analytics emit only after cookie consent and do not block form submission.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Release lane gaps</p>
+          <h2>External release evidence remains visible.</h2>
+          <p>
+            Pricing packages, marketplace offers, support operations, proof hub assets, showcase demos,
+            deployment validation, migration evidence, SDK harnesses, and broad 3D proof are owned by the
+            tickets linked above. This site should not promote those areas as shipped until those owners
+            publish evidence.
+          </p>
+          <div class="action-row">
+            <a
+              class="button button-primary"
+              href="pricing.html"
+              data-analytics-event="cta_click"
+              data-cta-location="claims-footer-cta"
+              data-cta-destination="pricing"
+            >Open Core</a>
+            <a
+              class="button button-secondary"
+              href="security.html"
+              data-analytics-event="cta_click"
+              data-cta-location="claims-footer-cta"
+              data-cta-destination="security"
+            >Security</a>
+            <a
+              class="button button-ghost"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-cta-location="claims-footer-cta"
+              data-cta-destination="contact"
+            >Talk to us</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="footer-band">
+          <div>
+            <p class="eyebrow">Trust</p>
+            <h2>Review the evidence before repeating a claim.</h2>
+            <p class="footer-copy">
+              Preview messaging can move quickly, but broad outreach needs source, proof, or an explicit
+              owner gap.
+            </p>
+          </div>
+          <div class="footer-actions">
+            <a class="button button-primary" href="docs.html">Read the docs</a>
+            <a class="button button-secondary" href="protocols.html">Compatibility</a>
+            <a
+              class="button button-ghost"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-cta-location="claims-footer"
+              data-cta-destination="contact"
+            >Talk to us</a>
+          </div>
+        </div>
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <p class="footer-copy">One geospatial foundation for every way your team works with spatial data.</p>
+          </div>
+          <div>
+            <p class="footer-title">Platform</p>
+            <a href="platform.html">Platform Overview</a>
+            <a href="agentic-gis.html">AI Agents</a>
+            <a href="runtime.html">gRPC Runtime</a>
+            <a href="devops.html">GitOps + OTel</a>
+          </div>
+          <div>
+            <p class="footer-title">Build</p>
+            <a href="modernization.html">Modernization</a>
+            <a href="docs.html">Documentation</a>
+            <a href="sdks.html">SDKs</a>
+            <a href="mobile.html">Field Toolkit</a>
+          </div>
+          <div>
+            <p class="footer-title">Trust</p>
+            <a href="protocols.html">Compatibility</a>
+            <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
+            <a href="security.html">Security</a>
+            <a href="privacy.html">Privacy</a>
+            <a href="terms.html">Terms</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/devops.html
+++ b/devops.html
@@ -6,7 +6,7 @@
     <title>Honua | GitOps + OpenTelemetry</title>
     <meta
       name="description"
-      content="Services defined in Git. Rollouts reviewed in PRs. OpenTelemetry traces from the edge into PostGIS. Six validated deploy targets on AWS and Azure."
+      content="Services defined in Git, rollouts reviewed in PRs, OpenTelemetry traces into PostGIS, and six AWS/Azure deployment paths tracked for Preview validation."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -61,8 +61,8 @@
             <h1>Run GIS like the rest of your production infrastructure.</h1>
             <p class="lede">
               Manifests in Git. Changes reviewed in PRs. OpenTelemetry traces from the client, through
-              the runtime, into PostGIS. Six validated deploy targets on AWS and Azure. Platform teams
-              run Honua the same way they run everything else.
+              the runtime, into PostGIS. Six AWS and Azure deployment paths are tracked for Preview validation.
+              Platform teams can evaluate Honua against their existing operations model.
             </p>
             <div class="action-row">
               <a class="button button-primary" href="docs.html#quickstart">Launch the quickstart</a>
@@ -164,7 +164,7 @@ status: ok</code></pre>
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">Deploy targets</p>
-            <h2>Six validated paths. Pick the one your team already runs.</h2>
+            <h2>Six targeted paths. Validate the one your team already runs.</h2>
           </div>
           <div class="table-wrap">
             <table>
@@ -195,7 +195,7 @@ status: ok</code></pre>
             </table>
           </div>
           <div class="callout">
-            All six targets are exercised in CI against the same runtime. Terraform modules for each live in <a class="text-link" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">honua-terraform</a>.
+            Deployment validation evidence is owned outside this site. Terraform modules and proof follow-up live in <a class="text-link" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">honua-terraform</a>.
           </div>
         </section>
 
@@ -203,8 +203,8 @@ status: ok</code></pre>
           <p class="eyebrow">Next</p>
           <h2>Wire it into your pipeline.</h2>
           <p>
-            Start with the quickstart to see the manifest format and trace output. Then clone the
-            Terraform modules and deploy against the target your team already uses.
+            Start with the quickstart to see the manifest format and trace output. Then review the
+            Terraform modules and validate the target your team already uses.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="docs.html#quickstart">Launch the quickstart</a>
@@ -220,8 +220,8 @@ status: ok</code></pre>
             <p class="eyebrow">Build the next layer</p>
             <h2>Run GIS the way you run everything else.</h2>
             <p class="footer-copy">
-              Manifests in Git, traces through the stack, six deploy targets ready to go. No separate
-              operational model for your spatial layer.
+              Manifests in Git, traces through the stack, and six deployment paths tracked for Preview validation.
+              Keep deployment claims tied to proof before production rollout.
             </p>
           </div>
           <div class="footer-actions">
@@ -253,6 +253,7 @@ status: ok</code></pre>
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/docs.html
+++ b/docs.html
@@ -199,8 +199,13 @@ PY</code></pre>
             </article>
             <article class="card card-link">
               <h3>Field toolkit</h3>
-              <p>See how offline sync and field workflows fit into the same platform story.</p>
+              <p>See the Beta/pilot framing for mobile storage, sync, and field workflows.</p>
               <a class="text-link" href="mobile.html">View field toolkit</a>
+            </article>
+            <article class="card card-link">
+              <h3>Claims matrix</h3>
+              <p>Check which public claims are source-backed, Preview partial, proof-pending, Beta, or deferred.</p>
+              <a class="text-link" href="claims.html">Review public claims</a>
             </article>
             <article class="card card-link">
               <h3>Open Core</h3>
@@ -288,6 +293,7 @@ PY</code></pre>
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -17,7 +17,7 @@ The canonical MVP conversion path is:
 2. `docs.html#quickstart` lets evaluators run Honua locally and continue into SDK, protocol, modernization, or platform detail pages.
 3. Site CTAs route commercial or migration conversations to `index.html#contact`, which is the MVP lead/demo endpoint until a sales-owned CRM or marketplace handoff is approved.
 
-CTA instrumentation belongs on site-owned links with `data-analytics-event`, `data-analytics-label`, and `data-analytics-destination` attributes. The analytics helper also accepts `data-cta-location` and `data-cta-destination` on claims-matrix links. Contact-form attribution is carried through hidden `lead_*` fields populated by `assets/analytics.js`.
+CTA instrumentation belongs on site-owned links with `data-analytics-event`, `data-analytics-label`, and `data-analytics-destination` attributes. The analytics helper also accepts `data-cta-location` and `data-cta-destination` on claims-matrix links. After analytics consent, contact-form attribution is carried through hidden `lead_*` fields populated by `assets/analytics.js`.
 
 ## Page Scope
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -26,6 +26,7 @@ Core MVP pages:
 - `index.html`: home page, proof summary, and canonical contact/demo form.
 - `docs.html`: quickstart and developer continuation path.
 - `pricing.html`: Open Core and commercial-entry language bounded to approved high-level categories.
+- `claims.html`: public claims matrix for Preview, Beta, proof-pending, external-owner, and deferred status review.
 - `modernization.html`: migration-assessment entry point for ArcGIS and GeoServer evaluators.
 - `protocols.html`: compatibility and proof entry point.
 - `privacy.html`, `terms.html`, and `security.html`: trust, data-handling, legal, and security posture.
@@ -54,6 +55,7 @@ Supporting pages should only change when needed for nav consistency, CTA routing
 ## Source Evidence
 
 - Pages: `*.html`
+- Public claims matrix: `claims.html`
 - Assets and navigation: `assets/`
 - Styles: `styles.css`
 - Deployment headers: `_headers`
@@ -76,4 +78,16 @@ The `proof-and-gtm-buyer-path` release lane spans multiple repositories. For `ho
 
 ## Boundary
 
-The site should describe shipped and near-term release paths, but product claims must be verified against `honua-server`, SDK, mobile, admin, and deployment repos before publication. Do not publish numeric pricing, pilot packages, SLAs, marketplace offer claims, or stronger proof claims in this repository until the owning tickets provide approved source-backed material.
+The site should describe shipped and near-term release paths, but product claims must be verified against `honua-server`, SDK, mobile, admin, sales, support, marketplace, and deployment repos before publication. Do not publish numeric pricing, pilot packages, SLAs, marketplace offer claims, or stronger proof claims in this repository until the owning tickets provide approved source-backed material.
+
+`claims.html` is the public review surface for this contract. Each major claim should resolve to one or more of these statuses: Source-backed, Preview partial, Proof pending, Roadmap / Beta, Deferred, or External owner.
+
+## Claims Maintenance
+
+Public product-claim edits must update `claims.html` in the same PR when they add, remove, promote, or soften a shipped, Preview, Beta, proof-pending, roadmap, or deferred claim.
+
+Each matrix row records the claim area, public pages, public wording rule, release status, evidence or owning issue, and review notes. Claims owned outside this repository should link the source, proof asset, or owner ticket rather than restating them as site-owned commitments.
+
+Keep low-noise discovery for the matrix through the footer Trust column plus contextual docs/pricing links. Do not crowd primary navigation unless the site information architecture changes.
+
+CTA and lead-form attribution remains consent-gated through `assets/analytics.js`. Analytics failures or missing consent must not block navigation or contact-form submission.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -17,7 +17,7 @@ The canonical MVP conversion path is:
 2. `docs.html#quickstart` lets evaluators run Honua locally and continue into SDK, protocol, modernization, or platform detail pages.
 3. Site CTAs route commercial or migration conversations to `index.html#contact`, which is the MVP lead/demo endpoint until a sales-owned CRM or marketplace handoff is approved.
 
-CTA instrumentation belongs on site-owned links with `data-analytics-event`, `data-analytics-label`, and `data-analytics-destination` attributes. Contact-form attribution is carried through hidden `lead_*` fields populated by `assets/analytics.js`.
+CTA instrumentation belongs on site-owned links with `data-analytics-event`, `data-analytics-label`, and `data-analytics-destination` attributes. The analytics helper also accepts `data-cta-location` and `data-cta-destination` on claims-matrix links. Contact-form attribution is carried through hidden `lead_*` fields populated by `assets/analytics.js`.
 
 ## Page Scope
 

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
     <title>Honua | One geospatial foundation for every team</title>
     <meta
       name="description"
-      content="Honua is one geospatial platform for everyone who touches spatial data — GIS analysts, non-specialists, developers, platform engineers, and AI agents. OGC conformant, ArcGIS and GeoServer compatible, cloud-native under the hood."
+      content="Honua is a Preview geospatial foundation for analysts, developers, platform teams, and AI agents, with documented OGC counts and ArcGIS/GeoServer compatibility paths that call out partial-parity caveats."
     />
     <meta property="og:title" content="Honua | One geospatial foundation for every team" />
     <meta
       property="og:description"
-      content="One platform for analysts, non-specialists, developers, platform engineers, and AI agents. Ask in English, build in your language, deploy like software."
+      content="A Preview geospatial foundation with documented compatibility paths, source-backed counts, and visible partial-parity caveats."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://honua.io" />
@@ -21,7 +21,7 @@
     <meta name="twitter:title" content="Honua | One geospatial foundation for every team" />
     <meta
       name="twitter:description"
-      content="One platform for analysts, non-specialists, developers, platform engineers, and AI agents."
+      content="Preview geospatial foundation with documented compatibility paths and partial-parity caveats."
     />
     <meta name="twitter:image" content="https://honua.io/assets/og-image.png" />
     <meta
@@ -110,8 +110,8 @@
             <div class="proof-row" aria-label="Platform proof points">
               <span class="proof-pill">OGC 137/137</span>
               <span class="proof-pill">gRPC native</span>
-              <span class="proof-pill">6 deploy targets</span>
-              <span class="proof-pill">MCP for agents</span>
+              <span class="proof-pill">6 targeted paths</span>
+              <span class="proof-pill">MCP preview</span>
             </div>
           </div>
 
@@ -173,7 +173,7 @@
             <span class="ticker-item">GeoServer compat</span><span class="ticker-sep">·</span>
             <span class="ticker-item">MCP for agents</span><span class="ticker-sep">·</span>
             <span class="ticker-item">PostGIS native</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">GeoPackage offline</span><span class="ticker-sep">·</span>
+            <span class="ticker-item">Field toolkit beta</span><span class="ticker-sep">·</span>
             <span class="ticker-item">OpenTelemetry</span><span class="ticker-sep">·</span>
             <span class="ticker-item">Open core · no seats</span><span class="ticker-sep">·</span>
             <span class="ticker-item">OGC API Features</span><span class="ticker-sep">·</span>
@@ -182,7 +182,7 @@
             <span class="ticker-item">GeoServer compat</span><span class="ticker-sep">·</span>
             <span class="ticker-item">MCP for agents</span><span class="ticker-sep">·</span>
             <span class="ticker-item">PostGIS native</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">GeoPackage offline</span><span class="ticker-sep">·</span>
+            <span class="ticker-item">Field toolkit beta</span><span class="ticker-sep">·</span>
             <span class="ticker-item">OpenTelemetry</span><span class="ticker-sep">·</span>
             <span class="ticker-item">Open core · no seats</span><span class="ticker-sep">·</span>
           </div>
@@ -193,7 +193,7 @@
             <p class="eyebrow">Why now</p>
             <h2>Spatial data used to live with the GIS team. Now every team is a spatial team.</h2>
             <p class="section-copy">
-              Policy wants answers. Product wants maps. Operations wants routing. Field wants offline sync.
+              Policy wants answers. Product wants maps. Operations wants routing. Field wants pilot-ready mobile workflows.
               Support wants territory views. Developers want typed SDKs. Platform engineers want something
               that runs on Kubernetes. AI agents want a protocol. None of today's tools were built to serve
               all of them at once. Honua is.
@@ -215,7 +215,7 @@
               <p class="card-kicker">01 · GIS Analysts &amp; Leads</p>
               <h3>Offload the routine. Own the hard work.</h3>
               <p>
-                Your ArcGIS Pro, QGIS, and GeoServer workflows keep running through the compatibility bridge.
+                Your ArcGIS Pro, QGIS, and GeoServer workflows stay on documented compatibility paths.
                 Agents and automation take the repetitive queries off your plate so you can spend your time on
                 the spatial analysis, data stewardship, and domain judgement only you can do. Honua is built to
                 make you the highest-leverage role in the room — not to work around you.
@@ -233,8 +233,8 @@
               <p class="card-kicker">03 · Developers</p>
               <h3>Typed contracts in your language.</h3>
               <p>
-                JavaScript, Python, .NET, MAUI mobile. gRPC under the hood. Offline-first sync for field apps.
-                One client surface across web, backend, desktop, and device.
+                JavaScript, Python, and .NET preview clients use gRPC under the hood. MAUI field workflows
+                remain Beta and pilot-scoped until field proof assets are linked.
               </p>
             </article>
             <article class="persona">
@@ -242,15 +242,15 @@
               <h3>A GIS that ships like your other services.</h3>
               <p>
                 Services defined in Git. Rollouts reviewed in PRs. OpenTelemetry traces through the runtime
-                into PostGIS. Six validated deploy targets on AWS and Azure.
+                into PostGIS. Six deployment paths are tracked for Preview validation on AWS and Azure.
               </p>
             </article>
             <article class="persona">
               <p class="card-kicker">05 · AI Agents</p>
               <h3>A protocol, not a parser.</h3>
               <p>
-                MCP-native access to every collection, schema, operation, and topology tool. Claude, GPT,
-                Cursor, or your own agent — no scraping, no ad hoc REST, safe by construction.
+                MCP-native discovery, schema inspection, filtered queries, and bounded spatial tools. Claude,
+                GPT, Cursor, or your own agent can evaluate the protocol without ad hoc REST wrappers.
               </p>
             </article>
           </div>
@@ -261,10 +261,10 @@
             <p class="eyebrow">01 · Talk to your data</p>
             <h2>Give every role access. Give your analyst leverage.</h2>
             <p class="section-copy">
-              Honua exposes every collection, schema, spatial operation, and topology tool through an MCP-native
-              agent interface. Claude, GPT, Cursor, or your own agent — they all speak it. Non-specialists can
-              self-serve the questions they used to queue. Analysts offload the routine and focus on the analysis
-              that needs their judgement.
+              Honua exposes MCP-native discovery, schema inspection, filtered queries, and bounded spatial
+              tools for agent workflows. Claude, GPT, Cursor, or your own agent can evaluate the protocol.
+              Non-specialists can self-serve scoped questions they used to queue. Analysts offload routine
+              discovery and focus on the analysis that needs their judgement.
             </p>
           </div>
           <div class="detail-grid">
@@ -295,8 +295,8 @@
             <p class="eyebrow">02 · SDKs for everything</p>
             <h2>Your developers ship in the language they already use.</h2>
             <p class="section-copy">
-              Typed contracts. Offline-first sync. One client surface across web, backend, desktop, and field.
-              Pick the runtime that fits the team and the job.
+              Typed contracts for Preview application paths and Beta field workflows. Pick the client surface
+              that fits the team and the job, then check the claims matrix for release status.
             </p>
           </div>
           <div class="sdk-grid">
@@ -342,9 +342,9 @@ var parcels = await c.Features("parcels")
             <article class="sdk">
               <header>
                 <span class="sdk-lang">MAUI</span>
-                <span class="sdk-use">field · offline</span>
+                <span class="sdk-use">field beta</span>
               </header>
-              <pre><code>// offline-first field collection
+              <pre><code>// beta field collection
 var local = await MobileStore.OpenAsync("survey");
 await local.Features("inspections")
            .UpsertAsync(reading);
@@ -362,17 +362,17 @@ await local.SyncWhenOnline();</code></pre>
             <p class="eyebrow">03 · Cloud-native runtime</p>
             <h2>Runs where your other services already run.</h2>
             <p class="section-copy">
-              gRPC under the hood, HTTP where it has to be. One binary that runs on the compute your team
-              already standardized on — validated end to end on AWS and Azure.
+              gRPC under the hood, HTTP where it has to be. One binary targets the compute your team already
+              standardized on, with AWS and Azure validation evidence tracked outside this site.
             </p>
           </div>
           <div class="deploy-grid">
-            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">ECS / Fargate</span><span class="deploy-status">validated</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">Lambda</span><span class="deploy-status">validated</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">EKS</span><span class="deploy-status">validated</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">Container Apps</span><span class="deploy-status">validated</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">Functions</span><span class="deploy-status">validated</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">AKS</span><span class="deploy-status">validated</span></article>
+            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">ECS / Fargate</span><span class="deploy-status">targeted</span></article>
+            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">Lambda</span><span class="deploy-status">targeted</span></article>
+            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">EKS</span><span class="deploy-status">targeted</span></article>
+            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">Container Apps</span><span class="deploy-status">targeted</span></article>
+            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">Functions</span><span class="deploy-status">targeted</span></article>
+            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">AKS</span><span class="deploy-status">targeted</span></article>
           </div>
           <div class="action-row">
             <a class="text-link" href="runtime.html">See the runtime →</a>
@@ -382,11 +382,11 @@ await local.SyncWhenOnline();</code></pre>
         <section class="section section-contrast" id="pillar-standards">
           <div class="section-heading">
             <p class="eyebrow">04 · Standards, everywhere</p>
-            <h2>Your ArcGIS and GeoServer clients keep working.</h2>
+            <h2>Your ArcGIS and GeoServer clients have compatibility paths.</h2>
             <p class="section-copy">
-              Standards aren't a bridge we're grudgingly maintaining — they're how most of your team still does
-              their best work. OGC API Features. WFS, WMS, WMTS. GeoServices REST. GeoPackage. STAC. COG. MVT.
-              Everything Pro, QGIS, and legacy web maps expect.
+              Standards are how most of your team still does its best work. OGC API Features, WFS, WMS,
+              WMTS, GeoServices REST, GeoPackage, STAC, COG, and MVT stay framed by the documented
+              compatibility evidence and partial-parity caveats.
             </p>
           </div>
           <div class="conformance">
@@ -422,7 +422,7 @@ await local.SyncWhenOnline();</code></pre>
             <h2>Run GIS the way you run the rest of your infrastructure.</h2>
             <p class="section-copy">
               Services defined in Git. Rollouts reviewed in PRs. Traces that reach from the edge into PostGIS.
-              An agent on call so your team doesn't have to be.
+              AI DevOps workflows remain framed as repo-backed automation, not a support commitment.
             </p>
           </div>
           <div class="card-grid card-grid-three">
@@ -438,8 +438,8 @@ await local.SyncWhenOnline();</code></pre>
             </article>
             <article class="card">
               <p class="card-kicker">AI DevOps</p>
-              <h3>An operator that doesn't sleep.</h3>
-              <p>Watches logs, triages pages, proposes fixes as pull requests. Your oncall reviews; it doesn't draft from scratch.</p>
+              <h3>Automation that proposes fixes.</h3>
+              <p>Watches logs, summarizes issues, and proposes pull requests where repo evidence supports the workflow. Your team reviews the change.</p>
             </article>
           </div>
           <div class="action-row">
@@ -450,11 +450,11 @@ await local.SyncWhenOnline();</code></pre>
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">If you're coming from ArcGIS or GeoServer</p>
-            <h2>Your existing stack keeps working while you build what's next.</h2>
+            <h2>Your existing stack gets a continuity plan while you build what's next.</h2>
             <p class="section-copy">
-              Service importers keep ArcGIS Pro, QGIS, and GeoServer-facing clients online through GeoServices
-              REST, WFS, WMS, WMTS, and OGC API. Validate the new runtime in parallel. Cut over when your team
-              is ready — on your schedule, not a vendor's.
+              Service importers, parity checks, and reconciliation are pilot-scoped until migration proof
+              assets are linked. Keep legacy clients on documented compatibility paths while new work
+              moves toward gRPC, SDKs, and agents.
             </p>
           </div>
           <div class="callout">
@@ -469,7 +469,7 @@ await local.SyncWhenOnline();</code></pre>
           <div class="contact-grid">
             <div class="contact-copy">
               <p class="eyebrow">Start a conversation</p>
-              <h2>Tell us what needs to keep working and what you want to improve.</h2>
+              <h2>Tell us which workflows need continuity and what you want to improve.</h2>
               <p>
                 Replacing ArcGIS or GeoServer. Moving apps to gRPC. Giving agents safe access to spatial data.
                 Standing up GitOps for publishing. Any of these is a fine first thread — or skip the form and
@@ -488,7 +488,15 @@ await local.SyncWhenOnline();</code></pre>
                 <span>Deployment and rollout planning</span>
               </div>
             </div>
-            <form class="contact-form" action="https://formsubmit.co/mike@honua.io" method="POST" data-contact-form>
+            <form
+              class="contact-form"
+              action="https://formsubmit.co/mike@honua.io"
+              method="POST"
+              data-contact-form
+              data-analytics-event="lead_form_submit"
+              data-analytics-label="home_contact_form"
+              data-analytics-destination="formsubmit"
+            >
               <input type="hidden" name="_captcha" value="true" />
               <input type="hidden" name="_subject" value="Honua.io migration assessment" />
               <input type="hidden" name="lead_landing_page" value="" />
@@ -580,6 +588,7 @@ await local.SyncWhenOnline();</code></pre>
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
               <a class="button button-ghost" href="#why-now">Why now</a>
             </div>
             <div class="proof-row" aria-label="Platform proof points">
-              <span class="proof-pill">OGC 137/137</span>
+              <span class="proof-pill">OGC API Features 137/137</span>
               <span class="proof-pill">gRPC native</span>
               <span class="proof-pill">6 targeted paths</span>
               <span class="proof-pill">MCP preview</span>

--- a/mobile.html
+++ b/mobile.html
@@ -6,7 +6,7 @@
     <title>Honua | Field Toolkit</title>
     <meta
       name="description"
-      content="MAUI-first offline field toolkit — GeoPackage storage, background sync, form workflows, one codebase for iOS / Android / Windows. Runs on the same Honua runtime as the rest of your stack."
+      content="Beta MAUI field toolkit scope for GeoPackage storage, sync, and form workflows. Pilot-scoped until field proof assets are linked."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -57,42 +57,42 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Field Toolkit</p>
-          <h1>Field work on the same runtime as everything else.</h1>
+          <h1>Beta field workflows on the same runtime boundary.</h1>
           <p class="page-intro">
-            A MAUI-first field toolkit with GeoPackage-backed offline storage, background sync, and form
-            workflows. One codebase across iOS, Android, and Windows. Same data model, same auth, same
-            operations as the central platform.
+            The MAUI-first field toolkit is Beta and pilot-scoped for Preview messaging. GeoPackage-backed
+            storage, sync, and form workflows should not be presented as Preview-ready until field proof
+            assets are linked.
           </p>
         </section>
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">What it covers</p>
-            <h2>Offline storage, background sync, guided collection.</h2>
+            <p class="eyebrow">Beta scope</p>
+            <h2>Offline storage, sync, and guided collection targets.</h2>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
               <p class="card-kicker">Offline</p>
               <h3>GeoPackage storage with queued edits.</h3>
               <p>
-                Maps, features, and edits persist on the device. Field teams keep working through
-                coverage gaps; edits flush when the network returns.
+                Maps, features, and edits are target capabilities for pilot validation. Field teams should
+                confirm coverage-gap behavior against their own proof run.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Sync</p>
               <h3>Background upload with conflict handling.</h3>
               <p>
-                gRPC-friendly transport, sync cursors, and conflict resolution so a week-long offline
-                stretch doesn't mean a week of manual reconciliation.
+                gRPC-friendly transport, sync cursors, and conflict handling remain Beta scope until repeatable
+                mobile proof assets are attached.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Forms</p>
               <h3>Validation, calculated fields, workflow rules.</h3>
               <p>
-                Collection forms with real field logic — required photos, conditional sections, derived
-                values — not a generic data-entry screen with asterisks.
+                Collection forms with required photos, conditional sections, and derived values are pilot-scoped
+                field workflow targets.
               </p>
             </article>
           </div>
@@ -108,16 +108,16 @@
               <p class="card-kicker">Shared data model</p>
               <h3>The schema your analysts use is the schema your field app uses.</h3>
               <p>
-                Collections, field definitions, and validation rules are defined once on Honua and
-                consumed by MAUI clients. No separate mobile data model to keep in sync.
+                Collections, field definitions, and validation rules are intended to flow from Honua into
+                MAUI clients, with pilot validation required for each field workflow.
               </p>
             </article>
             <article class="detail-card detail-card-spot">
               <p class="card-kicker">Shared operations</p>
               <h3>The same auth, traces, and rollout pipeline.</h3>
               <p>
-                Mobile requests flow through the same gRPC runtime and surface in the same OpenTelemetry
-                traces. Your platform team doesn't operate a second stack for field work.
+                Mobile requests are intended to flow through the same gRPC runtime and surface in the same
+                OpenTelemetry traces. Keep this as Beta scope until deployment evidence is linked.
               </p>
             </article>
           </div>
@@ -125,8 +125,8 @@
 
         <section class="section">
           <div class="section-heading">
-            <p class="eyebrow">What ships</p>
-            <h2>Toolkit components.</h2>
+            <p class="eyebrow">Beta / roadmap scope</p>
+            <h2>Toolkit components under pilot validation.</h2>
           </div>
           <div class="table-wrap">
             <table>
@@ -141,17 +141,17 @@
                 <tr>
                   <td data-label="Component">Transport + auth</td>
                   <td data-label="Purpose">Connect field apps to Honua services</td>
-                  <td data-label="Notes">Uses the same .NET SDK as backend services.</td>
+                  <td data-label="Notes">Beta path through the .NET SDK surface.</td>
                 </tr>
                 <tr>
                   <td data-label="Component">Offline engine</td>
                   <td data-label="Purpose">GeoPackage storage for maps and edits</td>
-                  <td data-label="Notes">Queues edits, flushes on reconnect.</td>
+                  <td data-label="Notes">Target behavior pending field proof assets.</td>
                 </tr>
                 <tr>
                   <td data-label="Component">Forms + workflows</td>
                   <td data-label="Purpose">Structured collection with validation</td>
-                  <td data-label="Notes">Calculated fields, conditional logic, required media.</td>
+                  <td data-label="Notes">Pilot-scoped workflow behavior.</td>
                 </tr>
                 <tr>
                   <td data-label="Component">MAUI integration</td>
@@ -165,10 +165,10 @@
 
         <section class="cta-band">
           <p class="eyebrow">Next</p>
-          <h2>Clone the repo. Open it in Visual Studio. Go.</h2>
+          <h2>Review the repo and scope a pilot.</h2>
           <p>
             The field toolkit lives at <a class="text-link" href="https://github.com/honua-io/honua-mobile" target="_blank" rel="noopener noreferrer">honua-io/honua-mobile</a>.
-            Point it at a Honua runtime and deploy to your test devices.
+            Treat it as Beta scope until your pilot produces repeatable field evidence.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="https://github.com/honua-io/honua-mobile" target="_blank" rel="noopener noreferrer">View the repo</a>
@@ -182,10 +182,10 @@
         <div class="footer-band">
           <div>
             <p class="eyebrow">Build the next layer</p>
-            <h2>Field teams work where the data lives.</h2>
+            <h2>Field workflows stay Beta until proof is linked.</h2>
             <p class="footer-copy">
-              One runtime, one data model, one auth boundary — all the way from central services down
-              to the phone in the field tech's pocket.
+              One runtime, one data model, and one auth boundary remain the target. Field claims stay
+              pilot-scoped until mobile evidence is attached.
             </p>
           </div>
           <div class="footer-actions">
@@ -217,6 +217,7 @@
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/modernization.html
+++ b/modernization.html
@@ -6,7 +6,7 @@
     <title>Honua | Modernize ArcGIS and GeoServer workloads</title>
     <meta
       name="description"
-      content="Import ArcGIS and GeoServer services into Honua, check parity against the existing runtime, and shift new work to gRPC APIs, SDKs, and AI agents — without breaking the clients your team already uses."
+      content="Plan ArcGIS and GeoServer migration pilots with import, parity, reconciliation, and cutover evidence kept proof-pending until owner tickets publish assets."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -60,18 +60,19 @@
           <h1>Move off legacy GIS without disrupting the people still using it.</h1>
           <p class="page-intro">
             Point existing ArcGIS Pro, QGIS, and GeoServer clients at Honua through the standards they already
-            speak. Import your current services with the toolkit. Validate parity. Shift new work to gRPC, SDKs,
-            and agents on your schedule.
+            speak where compatibility evidence supports the surface. Import, parity, reconciliation, and cutover
+            automation remain pilot-scoped until migration evidence is linked.
           </p>
         </section>
 
         <section id="arcgis-geoserver" class="section">
           <div class="section-heading">
             <p class="eyebrow">ArcGIS + GeoServer</p>
-            <h2>Keep the clients. Replace the backend.</h2>
+            <h2>Keep clients in scope while you prove parity.</h2>
             <p class="section-copy">
               Honua speaks GeoServices REST, WFS, WMS, WMTS, and OGC API — the protocols Pro, QGIS, and your
-              existing web maps already use. Swap the server without swapping the client.
+              existing web maps already use. Backend replacement should be planned through documented parity,
+              not stated as an unconditional client swap.
             </p>
           </div>
           <div class="detail-grid">
@@ -79,8 +80,8 @@
               <p class="card-kicker">ArcGIS workloads</p>
               <h3>FeatureServer, MapServer, raster, and geometry services on Honua.</h3>
               <p>
-                ArcGIS Pro, ArcGIS Online, the JS API, and any GeoServices REST client connects as if it were
-                talking to Server or Enterprise. Your team keeps the tools they know.
+                ArcGIS Pro, ArcGIS Online, the JS API, and GeoServices REST clients use a documented compatibility
+                path with parity gaps visible before rollout.
               </p>
             </article>
             <article class="detail-card detail-card-spot">
@@ -99,7 +100,7 @@
             <p class="eyebrow">How teams move</p>
             <h2>Import. Parity-check. Shift new work.</h2>
             <p class="section-copy">
-              Three steps, in order. Each one is validated before you move to the next.
+              Three steps, in order. Each one needs pilot evidence before public copy can claim it is complete.
             </p>
           </div>
           <div class="card-grid card-grid-three">
@@ -107,24 +108,24 @@
               <p class="card-kicker">1 · Import</p>
               <h3>Pull your current services into Honua.</h3>
               <p>
-                Service importers clone definitions, metadata, and runtime configuration from your existing
-                ArcGIS or GeoServer estate. Nothing gets recreated by hand.
+                Service importers target definitions, metadata, and runtime configuration from your existing
+                ArcGIS or GeoServer estate. Manual gaps stay visible until importer proof is linked.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">2 · Parity-check</p>
               <h3>Compare output side by side.</h3>
               <p>
-                Reconciliation tooling flags mismatches in data, rendering, response shape, and workflow behavior
-                before a single user sees anything change.
+                Reconciliation tooling is the target for flagging mismatches in data, rendering, response shape,
+                and workflow behavior before pilot rollout.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">3 · Shift</p>
               <h3>Move new work to gRPC, SDKs, and agents.</h3>
               <p>
-                Legacy clients stay on the compatibility surface. New apps go to typed contracts, offline-first
-                SDKs, and agent workflows. Both run on the same deployment.
+                Legacy clients stay on compatibility surfaces where parity is proven. New apps can pilot typed
+                contracts, Beta field SDKs, and agent workflows from the same deployment boundary.
               </p>
             </article>
           </div>
@@ -144,24 +145,24 @@
               <p class="card-kicker">Service importers</p>
               <h3>ArcGIS and GeoServer → Honua in one pass.</h3>
               <p>
-                Reads service definitions, publishes them on Honua, and preserves URLs where possible so clients
-                don't need reconfiguration.
+                Targets service definitions, publishes them on Honua, and preserves URLs where possible. Client
+                reconfiguration risk remains part of the pilot review.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Client code migration</p>
               <h3>Rewrite ArcGIS JS calls to Honua SDK.</h3>
               <p>
-                Scans JavaScript codebases, identifies the repeatable ArcGIS client patterns, and replaces them
-                with equivalent SDK calls. Leaves the non-trivial ones for you.
+                Scans JavaScript codebases, identifies repeatable ArcGIS client patterns, and suggests equivalent
+                SDK calls where migration evidence supports the rewrite.
               </p>
             </article>
             <article class="card">
               <p class="card-kicker">Parity checks</p>
               <h3>Catch drift before rollout.</h3>
               <p>
-                Runs your existing services against Honua and compares features, tiles, rendered maps, and
-                response shapes. Surfaces the diffs as an actionable list.
+                Targets comparisons for features, tiles, rendered maps, and response shapes. Published proof is
+                required before this becomes a shipped migration claim.
               </p>
             </article>
           </div>
@@ -183,7 +184,7 @@
               </thead>
               <tbody>
                 <tr>
-                  <td data-label="Old approach">Rewrite apps before the runtime is validated</td>
+                  <td data-label="Old approach">Rewrite apps before the runtime is parity-checked</td>
                   <td data-label="Where it breaks">Service behavior drifts; teams find out in production</td>
                   <td data-label="Honua approach">Parity-check the runtime first. Move apps once it passes.</td>
                 </tr>
@@ -195,7 +196,7 @@
                 <tr>
                   <td data-label="Old approach">All-or-nothing cutover</td>
                   <td data-label="Where it breaks">One dependency fails, everything rolls back</td>
-                  <td data-label="Honua approach">Legacy and modern clients run against the same service. Cut over piece by piece.</td>
+                  <td data-label="Honua approach">Run legacy and modern clients against pilot-scoped services. Cutover plans stay evidence-gated.</td>
                 </tr>
               </tbody>
             </table>
@@ -226,8 +227,8 @@
             <p class="eyebrow">Build the next layer</p>
             <h2>Modernize the platform without asking every user to change on day one.</h2>
             <p class="footer-copy">
-              Legacy clients keep working on the compatibility surface. New work moves to gRPC, SDKs, and agents.
-              Both run from the same deployment.
+              Legacy clients stay on documented compatibility surfaces while new work pilots gRPC, SDKs, and agents
+              from the same deployment boundary.
             </p>
           </div>
           <div class="footer-actions">
@@ -259,6 +260,7 @@
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/platform.html
+++ b/platform.html
@@ -6,7 +6,7 @@
     <title>Honua | Platform Overview</title>
     <meta
       name="description"
-      content="One geospatial runtime serving compatibility clients, gRPC applications, AI agents, and field tools from the same binary — deployed on the compute your team already runs."
+      content="One geospatial runtime serving compatibility clients, gRPC applications, Preview AI agents, and Beta field workflows from the same binary on targeted deployment paths."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -57,11 +57,11 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Platform overview</p>
-          <h1>One runtime. Five capabilities. Every user class.</h1>
+          <h1>One runtime. Five capabilities. Shared user classes.</h1>
           <p class="page-intro">
-            Honua is a single binary that serves compatibility clients, gRPC applications, AI agents,
-            and field tools — from the same deployment, against the same data, on the compute your
-            team already runs. This page is the architectural tour.
+            Honua is a single binary that serves documented compatibility clients, gRPC applications,
+            Preview AI agent surfaces, and Beta field workflows from the same deployment against the
+            same data. This page is the architectural tour.
           </p>
         </section>
 
@@ -81,9 +81,9 @@
               <a class="text-link" href="agentic-gis.html">See AI agents</a>
             </article>
             <article class="card card-link">
-              <p class="card-kicker">02 · SDKs for everything</p>
-              <h3>Typed clients in JS, Python, .NET, and MAUI.</h3>
-              <p>One client surface across web, backend, desktop, and field. gRPC under the hood; offline-first sync where you need it.</p>
+              <p class="card-kicker">02 · SDKs for apps</p>
+              <h3>Typed clients in JS, Python, .NET, and Beta MAUI.</h3>
+              <p>Preview client surfaces span web, backend, desktop, and pilot field workflows. gRPC is the shared protocol under the hood.</p>
               <a class="text-link" href="sdks.html">See the SDKs</a>
             </article>
             <article class="card card-link">
@@ -94,20 +94,20 @@
             </article>
             <article class="card card-link">
               <p class="card-kicker">04 · Compatibility</p>
-              <h3>Standards everywhere, conformance published.</h3>
-              <p>137/137 OGC API Features, WFS, WMS, WMTS, GeoServices REST. Your ArcGIS Pro and QGIS clients keep working.</p>
+              <h3>Standards with published evidence.</h3>
+              <p>137/137 OGC API Features plus documented WFS, WMS, WMTS, and GeoServices REST coverage with partial-parity caveats.</p>
               <a class="text-link" href="protocols.html">See compatibility</a>
             </article>
             <article class="card card-link">
               <p class="card-kicker">05 · Operate like software</p>
               <h3>GitOps, OpenTelemetry, AI DevOps.</h3>
-              <p>Services in Git, rollouts in PRs, traces through PostGIS. Six validated deploy targets on AWS and Azure.</p>
+              <p>Services in Git, rollouts in PRs, traces through PostGIS. Six AWS and Azure deployment paths are tracked for Preview validation.</p>
               <a class="text-link" href="devops.html">See operations</a>
             </article>
             <article class="card card-link">
               <p class="card-kicker">+ Field toolkit</p>
-              <h3>MAUI offline for iOS, Android, Windows.</h3>
-              <p>GeoPackage storage, background sync, form workflows. Same runtime, same data model, all the way to the device.</p>
+              <h3>Beta MAUI field toolkit for iOS, Android, Windows.</h3>
+              <p>GeoPackage storage, sync, and form workflows remain Beta or pilot-scoped until field proof assets are linked.</p>
               <a class="text-link" href="mobile.html">See the field toolkit</a>
             </article>
           </div>
@@ -116,10 +116,10 @@
         <section class="section section-contrast">
           <div class="section-heading">
             <p class="eyebrow">One runtime, many surfaces</p>
-            <h2>Every interface ships in the same process.</h2>
+            <h2>Documented interfaces share the same process.</h2>
             <p class="section-copy">
-              Current clients, new apps, AI agents, and analytics tools all read and write the same
-              data. Auth, permissions, and telemetry apply uniformly.
+              Compatibility clients, new apps, Preview AI agent surfaces, and analytics tools use the same
+              runtime boundary. Auth, permissions, and telemetry apply through the documented surfaces.
             </p>
           </div>
           <div class="table-wrap">
@@ -135,7 +135,7 @@
                 <tr>
                   <td data-label="Audience">ArcGIS Pro · Esri web apps · ArcGIS JS API</td>
                   <td data-label="Interface">GeoServices REST, MapServer, ImageServer, Geometry Service</td>
-                  <td data-label="What they get">Existing clients keep working. No porting project.</td>
+                  <td data-label="What they get">Documented compatibility paths, with parity gaps visible before rollout.</td>
                 </tr>
                 <tr>
                   <td data-label="Audience">QGIS · OpenLayers · Leaflet · Mapbox GL</td>
@@ -143,8 +143,8 @@
                   <td data-label="What they get">Standards-compliant access. Point the layer at Honua.</td>
                 </tr>
                 <tr>
-                  <td data-label="Audience">New apps, backends, mobile sync</td>
-                  <td data-label="Interface">gRPC + SDKs (JS / Python / .NET / MAUI)</td>
+                  <td data-label="Audience">New apps, backends, Beta field sync</td>
+                  <td data-label="Interface">gRPC + SDKs (JS / Python / .NET / Beta MAUI)</td>
                   <td data-label="What they get">Typed contracts, lower overhead, generated clients.</td>
                 </tr>
                 <tr>
@@ -171,8 +171,8 @@
             <p class="eyebrow">Deploy targets</p>
             <h2>Run it where your platform team already runs everything else.</h2>
             <p class="section-copy">
-              Six deploy targets on AWS and Azure, validated end-to-end in CI. Terraform modules for
-              every one live in <a class="text-link" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">honua-terraform</a>.
+              Six deployment paths on AWS and Azure are tracked for Preview validation. Terraform module
+              evidence remains owned outside this site in <a class="text-link" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">honua-terraform</a>.
             </p>
           </div>
           <div class="detail-grid">
@@ -200,8 +200,8 @@
               alt="Diagram showing clients, ingress, the Honua runtime, data services, and observability components."
             />
             <p class="image-caption">
-              One runtime serves compatibility traffic, application APIs, AI agent tooling, and field
-              sync — all from the same deployment.
+              One runtime serves compatibility traffic, application APIs, Preview AI agent tooling, and
+              Beta field sync from the same deployment boundary.
             </p>
           </div>
         </section>
@@ -210,8 +210,8 @@
           <p class="eyebrow">Next</p>
           <h2>Pick an entry point.</h2>
           <p>
-            Every capability page has working code. Every CTA on the home goes to one of them. Pick
-            the problem you care about most and start there.
+            Each capability page shows the current public framing and links toward the relevant evidence.
+            Pick the problem you care about most and start there.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="docs.html#quickstart">Launch the quickstart</a>
@@ -225,10 +225,10 @@
         <div class="footer-band">
           <div>
             <p class="eyebrow">Build the next layer</p>
-            <h2>One foundation for every user class.</h2>
+            <h2>One foundation for the main user classes.</h2>
             <p class="footer-copy">
-              Analysts, developers, platform engineers, field teams, AI agents — all served by the same
-              runtime, the same data model, the same operations.
+              Analysts, developers, platform engineers, field teams, and AI agents share the same runtime
+              boundary with Preview, Beta, and proof-pending scope kept visible.
             </p>
           </div>
           <div class="footer-actions">
@@ -260,6 +260,7 @@
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/pricing.html
+++ b/pricing.html
@@ -6,7 +6,7 @@
     <title>Honua | Open Core</title>
     <meta
       name="description"
-      content="Honua is an open-core geospatial platform. Self-host the runtime, SDKs, protocol specs, and mobile stack from GitHub — talk to us when you want commercial support or migration help."
+      content="Honua is an open-core geospatial platform. Self-host source-backed runtime and protocol paths from GitHub, with commercial support and pilot packaging owner-ticket gated."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -65,19 +65,19 @@
           <p class="eyebrow">Open Core</p>
           <h1>Self-host the platform. Talk to us when you want help.</h1>
           <p class="page-intro">
-            Honua is open core. The runtime, SDKs, protocol specs, mobile stack, and Terraform modules are all
-            public — clone a repo, read the code, run it yourself. Engage commercially when you need support,
-            migration delivery, or a hand in production.
+            Honua is open core. The runtime, protocol specs, SDK repositories, Beta mobile work, and deployment
+            modules are public source paths with different release statuses. Engage commercially when you need
+            support scope, migration delivery, or production planning.
           </p>
         </section>
 
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">What's open</p>
-            <h2>The platform you'd run in production is the same one on GitHub.</h2>
+            <h2>The public source paths are visible on GitHub.</h2>
             <p class="section-copy">
-              Not a reduced "community edition." The same binary, the same SDKs, the same protocol specs. What
-              you see in the repos is what you deploy.
+              Source availability is public, but Preview, Beta, and proof-pending claims still follow the
+              <a class="text-link" href="claims.html">claims matrix</a> before broad outreach.
             </p>
           </div>
           <div class="card-grid card-grid-three">
@@ -88,7 +88,7 @@
             </article>
             <article class="card">
               <p class="card-kicker">SDKs</p>
-              <h3>JS · Python · .NET · MAUI</h3>
+              <h3>JS · Python · .NET · MAUI Beta</h3>
               <p>
                 <a class="text-link" href="https://github.com/honua-io/honua-sdk-js" target="_blank" rel="noopener noreferrer">JS</a> ·
                 <a class="text-link" href="https://github.com/honua-io/honua-sdk-python" target="_blank" rel="noopener noreferrer">Python</a> ·
@@ -104,7 +104,7 @@
             <article class="card">
               <p class="card-kicker">Deployment</p>
               <h3>honua-terraform · honua-helm</h3>
-              <p>Terraform modules for six AWS/Azure targets plus a Helm chart for Kubernetes. <a class="text-link" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">terraform →</a> · <a class="text-link" href="https://github.com/honua-io/honua-helm" target="_blank" rel="noopener noreferrer">helm →</a></p>
+              <p>Terraform and Helm source paths for targeted deployment validation. <a class="text-link" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">terraform →</a> · <a class="text-link" href="https://github.com/honua-io/honua-helm" target="_blank" rel="noopener noreferrer">helm →</a></p>
             </article>
             <article class="card">
               <p class="card-kicker">Operations</p>
@@ -114,7 +114,7 @@
             <article class="card">
               <p class="card-kicker">Benchmarks</p>
               <h3>geobench</h3>
-              <p>Public benchmark suite so you can verify performance claims yourself. <a class="text-link" href="https://github.com/honua-io/geobench" target="_blank" rel="noopener noreferrer">GitHub →</a></p>
+              <p>Benchmark and proof assets stay proof-pending until public outputs are linked. <a class="text-link" href="https://github.com/honua-io/geobench" target="_blank" rel="noopener noreferrer">GitHub →</a></p>
             </article>
           </div>
         </section>
@@ -131,7 +131,7 @@
           <div class="detail-grid">
             <article class="detail-card detail-card-accent">
               <p class="card-kicker">Get it running</p>
-              <h3>Local in minutes, cloud in an afternoon.</h3>
+              <h3>Local quickly, cloud through tracked modules.</h3>
               <p>
                 Start with the
                 <a
@@ -143,15 +143,16 @@
                 >Docker quickstart</a>,
                 point a standards client at it, confirm your data flows. When you're ready, the
                 <a class="text-link" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">Terraform modules</a>
-                take you to ECS/Fargate, Lambda, EKS, Azure Container Apps, Functions, or AKS.
+                target ECS/Fargate, Lambda, EKS, Azure Container Apps, Functions, or AKS once validation
+                evidence is available.
               </p>
             </article>
             <article class="detail-card detail-card-spot">
               <p class="card-kicker">Keep it running</p>
-              <h3>Use the SDKs and MCP schema anywhere.</h3>
+              <h3>Use Preview SDKs and the MCP schema deliberately.</h3>
               <p>
-                Pick the SDK that matches your stack. Plug Honua into your existing agents via MCP.
-                Wire OpenTelemetry into the dashboards you already run. None of it requires permission from us.
+                Pick the SDK source path that matches your stack and check its release channel. Plug Honua into
+                MCP-aware agents for Preview evaluation, and wire OpenTelemetry into your existing dashboards.
               </p>
             </article>
           </div>
@@ -174,8 +175,8 @@
             </article>
             <article class="card">
               <p class="card-kicker">Support</p>
-              <h3>Production coverage planning.</h3>
-              <p>Scope support expectations, ownership boundaries, and operating coverage with the team that knows the runtime.</p>
+              <h3>Support scope and SLA terms.</h3>
+              <p>Support coverage, escalation, and SLA commitments are commercial terms, not public-site promises.</p>
             </article>
             <article class="card">
               <p class="card-kicker">Custom work</p>
@@ -192,7 +193,7 @@
           <p class="eyebrow">Next step</p>
           <h2>Evaluate on your own. Reach out when you want company.</h2>
           <p>
-            The fastest path is the quickstart. The fastest answer is the contact form.
+            The fastest path is the quickstart. The fastest scoped commercial answer is the contact form.
           </p>
           <div class="action-row">
             <a
@@ -220,7 +221,7 @@
             <p class="eyebrow">Build the next layer</p>
             <h2>Open source is the foundation. Help is available when you want it.</h2>
             <p class="footer-copy">
-              Self-host Honua end to end, or engage commercially when the migration, support model, or custom work
+              Self-host source-backed paths, or engage commercially when migration, support scope, or custom work
               is bigger than the platform itself.
             </p>
           </div>
@@ -265,6 +266,7 @@
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/privacy.html
+++ b/privacy.html
@@ -224,6 +224,7 @@
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/privacy.html
+++ b/privacy.html
@@ -60,7 +60,7 @@
           <h1>Limited site data, explicit consent, and clear contact handling.</h1>
           <p class="page-intro">
             honua.io is a product and documentation site. We only collect the information needed to respond to inbound
-            contact requests, understand the page path that led to them, and, if you consent, basic site analytics.
+            contact requests and, if you accept analytics, understand the site path that led to them.
           </p>
         </section>
 
@@ -72,7 +72,7 @@
           <div class="note-grid">
             <article class="note-card">
               <h3>Contact form submissions</h3>
-              <p>Name, work email, company, message, and limited lead-attribution context submitted through the site contact form.</p>
+              <p>Name, work email, company, message, and consented lead-attribution context submitted through the site contact form.</p>
             </article>
             <article class="note-card">
               <h3>Optional analytics</h3>
@@ -80,7 +80,7 @@
             </article>
             <article class="note-card">
               <h3>Session attribution</h3>
-              <p>Landing page, referrer, UTM campaign fields, and the most recent CTA may be stored for the current browser session.</p>
+              <p>After analytics consent, landing page, referrer, UTM campaign fields, and the most recent CTA may be stored for the current browser session.</p>
             </article>
             <article class="note-card">
               <h3>Basic server logs</h3>
@@ -113,7 +113,7 @@
                 </tr>
                 <tr>
                   <td>Lead-attribution context</td>
-                  <td>Understand which site path, campaign, or CTA led to an inquiry so follow-up can stay relevant.</td>
+                  <td>After analytics consent, understand which site path, campaign, or CTA led to an inquiry so follow-up can stay relevant.</td>
                 </tr>
                 <tr>
                   <td>Consented analytics</td>
@@ -143,7 +143,7 @@
               <h2>No analytics before consent.</h2>
               <p>
                 Honua does not load Google Analytics until you click <strong>Accept analytics</strong> in the cookie banner.
-                Contact-form attribution uses current-session browser storage and is separate from analytics consent.
+                CTA and contact-form attribution use current-session browser storage only after that consent.
               </p>
             </article>
             <article class="detail-card">

--- a/protocols.html
+++ b/protocols.html
@@ -6,7 +6,7 @@
     <title>Honua | Compatibility &amp; Standards</title>
     <meta
       name="description"
-      content="ArcGIS Pro, QGIS, web maps, and partner clients stay connected to Honua through OGC, WFS, WMS, WMTS, and GeoServices REST. Published conformance counts and the open protocol path for the gRPC and MCP work."
+      content="ArcGIS Pro, QGIS, web maps, and partner clients use documented Honua compatibility paths through OGC, WFS, WMS, WMTS, and GeoServices REST, with published counts and caveats."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -57,20 +57,20 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">Compatibility</p>
-          <h1>Your existing GIS clients keep working.</h1>
+          <h1>Your existing GIS clients have documented compatibility paths.</h1>
           <p class="page-intro">
             ArcGIS Pro, QGIS, OpenLayers, Leaflet, Mapbox GL, ESRI JS API, and any OGC-compliant client
-            stay connected to Honua through the standards they already speak. The full conformance surface,
-            the test counts, and the open protocol work are all published below.
+            can connect to Honua through the standards they already speak where parity is documented. The
+            conformance surface, test counts, and open protocol work are published below with caveats.
           </p>
         </section>
 
         <section class="section">
           <div class="section-heading">
             <p class="eyebrow">What stays connected</p>
-            <h2>Point your existing tools at Honua. They work.</h2>
+            <h2>Point existing tools at documented surfaces.</h2>
             <p class="section-copy">
-              No plugin, no client rewrite, no sidecar. If it speaks the standards on this page, it speaks Honua.
+              For the surfaces on this page, compatibility is scoped by the linked evidence and partial-parity notes.
             </p>
           </div>
           <div class="card-grid card-grid-three">
@@ -92,7 +92,7 @@
             <article class="card">
               <p class="card-kicker">Existing integrations</p>
               <h3>GeoServer-facing clients</h3>
-              <p>Honua speaks the same WFS / WMS / WMTS. Swap the backend without swapping the client.</p>
+              <p>Honua speaks WFS, WMS, and WMTS so backend replacement can be planned before client rewrites.</p>
             </article>
             <article class="card">
               <p class="card-kicker">Data ecosystem</p>
@@ -102,7 +102,7 @@
             <article class="card">
               <p class="card-kicker">Generic</p>
               <h3>Any OGC API Features client</h3>
-              <p>Standard OGC clients — including anything generated from the spec — work out of the box.</p>
+              <p>Standard OGC API Features clients can use the documented Features surface.</p>
             </article>
           </div>
         </section>
@@ -112,20 +112,20 @@
             <p class="eyebrow">Conformance</p>
             <h2>Measured against the public test suites.</h2>
             <p class="section-copy">
-              Every count here comes from the published OGC and standards-body test harnesses, run against the
-              same runtime you'd deploy.
+              Counts here are limited to the linked OGC and standards-body test evidence for the current
+              Preview runtime.
             </p>
           </div>
           <div class="card-grid card-grid-three">
             <article class="card">
               <p class="card-kicker">OGC API Features</p>
               <h3>137 / 137 tests passing</h3>
-              <p>Collections, filtering, and standards-based feature access fully validated.</p>
+              <p>Collections, filtering, and standards-based feature access backed by the published count.</p>
             </article>
             <article class="card">
               <p class="card-kicker">OGC API Tiles</p>
               <h3>16 / 16 tests passing</h3>
-              <p>Vector and raster tile delivery validated against the published test suite.</p>
+              <p>Vector and raster tile delivery backed by the published test suite count.</p>
             </article>
             <article class="card">
               <p class="card-kicker">OGC API Maps</p>
@@ -140,12 +140,12 @@
             <article class="card">
               <p class="card-kicker">WMTS 1.0</p>
               <h3>118 / 118 tests passing</h3>
-              <p>Tile-serving behavior validated through the complete conformance suite.</p>
+              <p>Tile-serving behavior covered by the published conformance count.</p>
             </article>
             <article class="card">
               <p class="card-kicker">WFS 2.0</p>
-              <h3>Full suite passing</h3>
-              <p>Feature access and transactional operations validated through the complete OGC test harness.</p>
+              <h3>Preview partial</h3>
+              <p>Feature access is supported with partial parity; transactional proof remains owner-ticket gated.</p>
             </article>
           </div>
         </section>
@@ -155,8 +155,8 @@
             <p class="eyebrow">API surface</p>
             <h2>Standards, compatibility, and modern APIs — one deployment.</h2>
             <p class="section-copy">
-              Everything below ships in the same binary. A WFS client and a gRPC client can point at the same
-              service at the same time.
+              The documented surfaces share the same binary. A WFS client and a gRPC client can point at the
+              same service where the target surface is enabled.
             </p>
           </div>
           <div class="table-wrap">
@@ -182,7 +182,7 @@
                 <tr>
                   <td data-label="Surface">Modern APIs</td>
                   <td data-label="What it covers">gRPC, SDKs (JS / Python / .NET / MAUI), MCP</td>
-                  <td data-label="When to reach for it">New apps, automation, field collection, and AI agents.</td>
+                  <td data-label="When to reach for it">New apps, automation, Beta field collection, and Preview AI agents.</td>
                 </tr>
               </tbody>
             </table>
@@ -223,7 +223,7 @@
 
         <section class="cta-band">
           <p class="eyebrow">See it in context</p>
-          <h2>Conformance is the proof. The runtime is where it gets useful.</h2>
+          <h2>Conformance evidence keeps the runtime claims grounded.</h2>
           <p>
             The runtime, SDK, and modernization pages each show a concrete slice of what the compatibility
             story enables in a real deployment.
@@ -242,7 +242,7 @@
             <p class="eyebrow">Build the next layer</p>
             <h2>Evaluate Honua against the specs, not the pitch.</h2>
             <p class="footer-copy">
-              Every conformance count on this page comes from the public test suites. Run them yourself — the runtime is the same one you'd deploy.
+              Conformance counts on this page stay tied to published evidence and Preview caveats.
             </p>
           </div>
           <div class="footer-actions">
@@ -274,6 +274,7 @@
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/runtime.html
+++ b/runtime.html
@@ -156,7 +156,7 @@ message QueryFeaturesRequest {
                 <tr>
                   <td data-label="Audience">Current GIS clients</td>
                   <td data-label="Interface">GeoServices REST, OGC APIs, WFS, WMS, WMTS</td>
-                  <td data-label="What they get">ArcGIS Pro and QGIS keep working. No porting project.</td>
+                  <td data-label="What they get">Documented compatibility paths with parity gaps reviewed before rollout.</td>
                 </tr>
                 <tr>
                   <td data-label="Audience">New application teams</td>
@@ -209,8 +209,8 @@ message QueryFeaturesRequest {
           <p class="eyebrow">Next</p>
           <h2>Try it hands-on. Pick an SDK. Check the specs.</h2>
           <p>
-            The quickstart brings up a runtime locally. The SDK pages show what client code looks like.
-            The compatibility page shows what ships alongside gRPC in the same binary.
+            The quickstart brings up a runtime locally. The SDK pages show Preview client examples.
+            The compatibility page shows documented surfaces alongside gRPC in the same binary.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="docs.html#quickstart">Launch the quickstart</a>
@@ -258,6 +258,7 @@ message QueryFeaturesRequest {
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/sdks.html
+++ b/sdks.html
@@ -6,7 +6,7 @@
     <title>Honua | SDKs</title>
     <meta
       name="description"
-      content="Typed SDKs for JavaScript, Python, .NET, and MAUI mobile. Same client surface across web, backend, desktop, and field — all open source on GitHub."
+      content="Preview typed SDK surfaces for JavaScript, Python, .NET, and Beta MAUI field workflows, with source links and release-status caveats."
     />
     <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -57,11 +57,11 @@
       <main>
         <section class="page-hero">
           <p class="eyebrow">SDKs</p>
-          <h1>Four SDKs. One client surface.</h1>
+          <h1>SDK surfaces with release status kept visible.</h1>
           <p class="page-intro">
-            JavaScript, Python, .NET, and MAUI mobile. Typed contracts everywhere. gRPC under the hood.
-            Same auth, same data model, same call shape — whether you're building a web app, a
-            backend service, a desktop client, or a field tool.
+            JavaScript, Python, and .NET client examples show the Preview typed contract shape. MAUI mobile
+            remains Beta or pilot-scoped until field proof assets are linked. gRPC is the shared protocol
+            under the hood.
           </p>
         </section>
 
@@ -108,9 +108,9 @@ var parcels = await c.Features("parcels")
               <a class="text-link" href="https://github.com/honua-io/honua-sdk-dotnet" target="_blank" rel="noopener noreferrer">honua-io/honua-sdk-dotnet →</a>
             </article>
             <article class="card">
-              <p class="card-kicker">MAUI · field / offline</p>
-              <h3>Offline-first mobile across iOS, Android, and Windows.</h3>
-              <pre><code>// offline-first field collection
+              <p class="card-kicker">MAUI · field beta</p>
+              <h3>Beta mobile workflows across iOS, Android, and Windows.</h3>
+              <pre><code>// beta field collection
 var local = await MobileStore.OpenAsync("survey");
 await local.Features("inspections")
            .UpsertAsync(reading);
@@ -123,10 +123,10 @@ await local.SyncWhenOnline();</code></pre>
         <section class="section section-contrast">
           <div class="section-heading">
             <p class="eyebrow">Beyond the base client</p>
-            <h2>What else ships with the SDKs.</h2>
+            <h2>What else belongs to SDK release scope.</h2>
             <p class="section-copy">
-              Each SDK includes base client bindings plus specialized packages for the work that comes
-              up again and again.
+              Base client bindings are Preview-oriented until package and harness evidence is linked. Specialized
+              packages stay scoped to their owning repositories and release channels.
             </p>
           </div>
           <div class="detail-grid">
@@ -134,8 +134,8 @@ await local.SyncWhenOnline();</code></pre>
               <p class="card-kicker">Migration helpers · JavaScript</p>
               <h3>Rewrite ArcGIS client code to the Honua SDK.</h3>
               <p>
-                Scan JS codebases, identify common ArcGIS client patterns, and rewrite them where the
-                automation can do it safely. Leaves the non-trivial ones for review.
+                Scan JS codebases, identify common ArcGIS client patterns, and suggest replacements where
+                the migration evidence supports it. Leaves the non-trivial ones for review.
               </p>
             </article>
             <article class="detail-card detail-card-spot">
@@ -157,12 +157,12 @@ await local.SyncWhenOnline();</code></pre>
           <div class="card-grid card-grid-three">
             <article class="card card-link">
               <h3>Field toolkit</h3>
-              <p>MAUI-first field tooling with GeoPackage offline, sync, and form workflows.</p>
+              <p>Beta MAUI field tooling with GeoPackage storage, sync, and form workflows.</p>
               <a class="text-link" href="mobile.html">See the field toolkit</a>
             </article>
             <article class="card card-link">
               <h3>AI agents</h3>
-              <p>MCP-native access to every collection, schema, and spatial operation. Works with Claude, GPT, Cursor, or your own agent.</p>
+              <p>MCP-native discovery, schema inspection, filtered queries, and bounded spatial tools for Preview evaluation.</p>
               <a class="text-link" href="agentic-gis.html">See AI agents</a>
             </article>
             <article class="card card-link">
@@ -175,10 +175,10 @@ await local.SyncWhenOnline();</code></pre>
 
         <section class="cta-band">
           <p class="eyebrow">Next</p>
-          <h2>Install the SDK. Point it at a local runtime. Make a call.</h2>
+          <h2>Try an SDK from source. Point it at a local runtime. Make a call.</h2>
           <p>
-            The quickstart brings up Honua in Docker. Pick an SDK, install it, and you're making live
-            requests against your own server in a few minutes.
+            The quickstart brings up Honua in Docker. Pick an SDK source path, check its release channel,
+            and make live requests against your own server.
           </p>
           <div class="action-row">
             <a class="button button-primary" href="docs.html#quickstart">Launch the quickstart</a>
@@ -192,10 +192,10 @@ await local.SyncWhenOnline();</code></pre>
         <div class="footer-band">
           <div>
             <p class="eyebrow">Build the next layer</p>
-            <h2>Every team gets a typed way in.</h2>
+            <h2>Each team gets a typed way in.</h2>
             <p class="footer-copy">
-              Web, backend, desktop, mobile — same runtime, same contracts, same SDK shape. The work
-              is the work; the client doesn't get in the way.
+              Web, backend, desktop, and Beta mobile workflows share the runtime boundary, with SDK release
+              status kept visible.
             </p>
           </div>
           <div class="footer-actions">
@@ -227,6 +227,7 @@ await local.SyncWhenOnline();</code></pre>
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/security.html
+++ b/security.html
@@ -208,6 +208,7 @@
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>

--- a/styles.css
+++ b/styles.css
@@ -423,6 +423,58 @@ h3 {
   font-weight: 600;
 }
 
+.status-tag {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin: 2px 6px 2px 0;
+  padding: 6px 9px;
+  border: 1px solid rgba(142, 190, 185, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted-strong);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.status-source {
+  color: var(--accent-strong);
+  background: rgba(38, 216, 173, 0.11);
+}
+
+.status-preview {
+  color: var(--blue);
+  background: rgba(87, 198, 255, 0.11);
+}
+
+.status-pending {
+  color: var(--spot);
+  background: rgba(242, 197, 107, 0.12);
+}
+
+.status-beta,
+.status-external {
+  color: var(--muted-strong);
+  background: rgba(155, 180, 176, 0.09);
+}
+
+.status-deferred {
+  color: #ffb7a6;
+  background: rgba(255, 183, 166, 0.1);
+}
+
+.claims-table td:first-child {
+  min-width: 190px;
+}
+
+.claims-table td:nth-child(3) {
+  min-width: 240px;
+}
+
 .proof-pill::before,
 .contact-points span::before {
   content: "";

--- a/terms.html
+++ b/terms.html
@@ -175,6 +175,7 @@
             <p class="footer-title">Trust</p>
             <a href="protocols.html">Compatibility</a>
             <a href="pricing.html">Open Core</a>
+            <a href="claims.html">Claims Matrix</a>
             <a href="security.html">Security</a>
             <a href="privacy.html">Privacy</a>
             <a href="terms.html">Terms</a>


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #17
## Summary

Preview release claims matrix for source-backed public messaging
## Changes Made

- Preview release claims matrix for source-backed public messaging
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
Bounded audit covered analytics init, CTA click, contact form bind/submit, accept, decline, reset, stored accepted/declined states, storage failures, and UTM parsing. There are no async retry/timeout ownership paths in this static module beyond best-effort GA loading.

Follow-ons:
None.

Code kaizen:
Skipped by kaizen policy.
