### PR TITLE
feat: Lead capture instrumentation and CRM handoff (forms + attribution) (#honua-site-3)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Validate lead capture contract
+        run: ./scripts/validate-lead-capture.sh
       - name: Build artifact
         run: ./scripts/build-dist.sh
       - name: Validate artifact security headers

--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Repository layout:
 - `privacy.html` - privacy and cookie notice
 - `terms.html` - site terms of use
 - `security.html` - security contact and DPA posture
+- `docs/lead-capture-handoff.md` - contact form attribution, CRM handoff, smoke evidence, and downstream ownership
 - `styles.css` - site styles
 - `assets/` - static assets, navigation JavaScript, and consent-gated analytics/CTA attribution
 - `_headers` - deployment response headers (CSP, clickjacking, and related security headers)
 - `scripts/build-dist.sh` - build the deployable static artifact
+- `scripts/validate-lead-capture.sh` - validate the contact form, attribution fields, CTA metadata, CSP allowlist, and handoff docs
 - `scripts/validate-security-headers.sh` - validate live security headers when a target URL is configured
 - `scripts/validate-workflow-pinning.sh` - verify workflow actions remain pinned
 - `.github/workflows/` - CI/deploy workflows

--- a/ai-gis.html
+++ b/ai-gis.html
@@ -36,7 +36,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html" aria-current="page">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="ai_gis_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -54,7 +60,13 @@
             Same audit log, same governance, same MCP plumbing for all three.
           </p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a
+              class="btn btn-primary"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-analytics-label="ai_gis_hero_contact"
+              data-analytics-destination="index.html#contact"
+            >Talk to us</a>
             <a class="btn btn-ghost" href="https://github.com/honua-io/geospatial-mcp" target="_blank" rel="noopener noreferrer">MCP spec ↗</a>
           </div>
         </div>
@@ -177,7 +189,13 @@
         <span class="eyebrow">// next</span>
         <h2>Run your whole<br /><span class="teal">GIS workflow with AI.</span></h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="ai_gis_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="https://github.com/honua-io/geospatial-mcp" target="_blank" rel="noopener noreferrer">MCP spec ↗</a>
         </div>
       </section>

--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -291,7 +291,7 @@
             form.dataset.ctaLocation ||
             (form.elements.lead_cta_label ? form.elements.lead_cta_label.value || "contact_form" : "contact_form"),
           destination: form.dataset.analyticsDestination || form.dataset.ctaDestination || "formsubmit",
-          lead_current_page: currentPage(),
+          page_location: currentPage(),
           transport_type: "beacon"
         });
       });

--- a/claims.html
+++ b/claims.html
@@ -33,7 +33,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="claims_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -190,7 +196,13 @@
         <span class="eyebrow">// next</span>
         <h2>Read the pillars.<br /><span class="teal">Every claim links back here.</span></h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="claims_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="interoperability.html">Compatibility</a>
         </div>
       </section>

--- a/cloud-native.html
+++ b/cloud-native.html
@@ -36,7 +36,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="cloud_native_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -52,7 +58,13 @@
             two years ago. The GIS stack stops needing its own ops queue.
           </p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a
+              class="btn btn-primary"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-analytics-label="cloud_native_hero_contact"
+              data-analytics-destination="index.html#contact"
+            >Talk to us</a>
             <a class="btn btn-ghost" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">Terraform module ↗</a>
             <a class="btn btn-ghost" href="operations.html">Simple operations →</a>
           </div>
@@ -134,7 +146,13 @@
         <span class="eyebrow">// next</span>
         <h2>Compose the platform from <span class="teal">primitives you already run.</span></h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="cloud_native_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="operations.html">Simple operations</a>
         </div>
       </section>

--- a/docs.html
+++ b/docs.html
@@ -37,7 +37,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="docs_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -17,7 +17,7 @@ The canonical MVP conversion path is:
 2. `docs.html#quickstart` lets evaluators run Honua locally and continue into SDK, protocol, modernization, or platform detail pages.
 3. Site CTAs route commercial or migration conversations to `index.html#contact`, which is the MVP lead/demo endpoint until a sales-owned CRM or marketplace handoff is approved.
 
-CTA instrumentation belongs on site-owned links with `data-analytics-event`, `data-analytics-label`, and `data-analytics-destination` attributes. The analytics helper also accepts `data-cta-location` and `data-cta-destination` on claims-matrix links. After analytics consent, contact-form attribution is carried through hidden `lead_*` fields populated by `assets/analytics.js`.
+CTA instrumentation belongs on site-owned links with `data-analytics-event`, `data-analytics-label`, and `data-analytics-destination` attributes. The analytics helper also accepts `data-cta-location` and `data-cta-destination` on claims-matrix links. After analytics consent, contact-form attribution is carried through hidden `lead_*` fields populated by `assets/analytics.js`. The lead payload, CRM handoff, smoke evidence, and downstream ownership model are documented in [Lead Capture And CRM Handoff](../lead-capture-handoff.md).
 
 ## Page Scope
 
@@ -56,6 +56,7 @@ Supporting pages should only change when needed for nav consistency, CTA routing
 
 - Pages: `*.html`
 - Public claims matrix: `claims.html`
+- Lead capture and CRM handoff: `docs/lead-capture-handoff.md`
 - Assets and navigation: `assets/`
 - Styles: `styles.css`
 - Deployment headers: `_headers`
@@ -65,10 +66,10 @@ Supporting pages should only change when needed for nav consistency, CTA routing
 
 ## Release Gaps
 
-The `proof-and-gtm-buyer-path` release lane spans multiple repositories. For `honua-site#1`, site-owned work is limited to IA, CTA routing, and attribution. The remaining release-lane gaps stay bounded to their owning tickets:
+The `proof-and-gtm-buyer-path` release lane spans multiple repositories. Site-owned work is limited to IA, CTA routing, attribution, the static form contract, and proof links. The remaining release-lane gaps stay bounded to their owning tickets:
 
-- `honua-site#3`: CRM/marketplace handoff wiring, monitoring, and alerting beyond the static FormSubmit MVP.
-- `honua-site#9`: proof hub that publishes benchmarks, compatibility matrix, migration evidence, and reference architecture as source assets become release-backed.
+- `honua-site#3`: static form contract, CTA instrumentation, consent-gated attribution, and handoff evidence. CRM monitoring and failed-sync alerting remain sales/support-owned unless a secure site-owned ingestion endpoint is approved.
+- `honua-site#9`: proof hub that publishes benchmarks, compatibility matrix, migration evidence, and reference architecture after source assets are supplied.
 - `honua-site#17`: public claims matrix mapping every site claim to source, proof, or roadmap status.
 - `honua-marketplace#3`: marketplace handoff target, offer/listing package, activation, and publish evidence.
 - `honua-sales#4`, `honua-sales#5`, `honua-sales#6`, `honua-sales#18`, and `honua-sales#25`: pricing, pilot packaging, sales handoff model, roles, SLAs, escalation, and content-owner commitments.

--- a/docs/lead-capture-handoff.md
+++ b/docs/lead-capture-handoff.md
@@ -1,0 +1,82 @@
+# Lead Capture And CRM Handoff
+
+This repository owns the public-site contact form and consent-gated attribution fields. Downstream CRM import, sales ownership, missed-follow-up escalation, and failed-sync alerting are owned outside this static site.
+
+## Site-Owned Entry Points
+
+- Canonical form: `index.html#contact`
+- Current form action: `https://formsubmit.co/mike@honua.io`
+- Current method: `POST`
+- Conversion event: `lead_form_submit`
+- CTA click event: `cta_click`
+- Shared implementation: `assets/analytics.js`
+- Deployment allowlist: `_headers` and the `index.html` Content Security Policy allow `form-action 'self' https://formsubmit.co`
+
+Site-owned commercial, contact, quickstart, and Open Core CTA buttons carry stable `data-analytics-event`, `data-analytics-label`, and `data-analytics-destination` attributes. The analytics helper records the most recent consenting CTA in session storage and copies it into the next contact-form submission.
+
+## Submitted Payload Schema
+
+The form intentionally submits contact fields to the form handler, not to analytics:
+
+| Field | Owner | Purpose |
+| --- | --- | --- |
+| `name` | Visitor | Person requesting follow-up. |
+| `email` | Visitor | Reply address for sales or support follow-up. |
+| `company` | Visitor | Optional organization context. |
+| `message` | Visitor | Optional inquiry details. |
+| `lead_landing_page` | Site attribution | First consenting page observed in the current browser session. |
+| `lead_current_page` | Site attribution | Page where the form was submitted. |
+| `lead_referrer` | Site attribution | Browser referrer captured after analytics consent. |
+| `lead_utm_source` | Site attribution | Consented `utm_source` value. |
+| `lead_utm_medium` | Site attribution | Consented `utm_medium` value. |
+| `lead_utm_campaign` | Site attribution | Consented `utm_campaign` value. |
+| `lead_utm_term` | Site attribution | Consented `utm_term` value. |
+| `lead_utm_content` | Site attribution | Consented `utm_content` value. |
+| `lead_cta_label` | Site attribution | Stable label for the most recent consenting CTA click. |
+| `lead_cta_page` | Site attribution | Page where the most recent consenting CTA was clicked. |
+| `lead_cta_href` | Site attribution | Destination for the most recent consenting CTA click. |
+
+Analytics events must not include `name`, `email`, `company`, or `message` values. The `lead_form_submit` event only sends conversion metadata such as event category, label, destination, page location, and beacon transport.
+
+## Consent And Failure Behavior
+
+Attribution is consent-gated. If a visitor accepts analytics, `assets/analytics.js` stores UTM, landing, referrer, and CTA context in current-session browser storage and refreshes hidden form fields before submit.
+
+If analytics consent is declined, unavailable, or revoked, the form remains usable and the `lead_*` fields are blank. Browser storage errors, analytics load failures, and `gtag` errors are caught so navigation and form submission continue.
+
+## CRM Handoff Expectations
+
+The MVP handoff is FormSubmit email intake to `mike@honua.io`. Sales-owned CRM processing should map the submitted fields without changing the public-site contract:
+
+| CRM concept | Site field |
+| --- | --- |
+| Contact name | `name` |
+| Work email | `email` |
+| Account/company | `company` |
+| Inquiry notes | `message` |
+| Lead source detail | `lead_landing_page`, `lead_current_page`, `lead_referrer` |
+| Campaign attribution | `lead_utm_source`, `lead_utm_medium`, `lead_utm_campaign`, `lead_utm_term`, `lead_utm_content` |
+| CTA attribution | `lead_cta_label`, `lead_cta_page`, `lead_cta_href` |
+
+Sales or support must own CRM import status, lead owner assignment, follow-up SLA evidence, missed-follow-up escalation, and failed lead sync alerting. This static site has no secure CRM ingestion endpoint and must not publish CRM keys or private workflow credentials in HTML or JavaScript.
+
+Failed lead sync alerting evidence must come from the sales or support workflow that owns CRM intake monitoring.
+
+## Smoke Evidence
+
+CI validates the static contract only. Manual release evidence should attach:
+
+1. Accepted-consent smoke: open `index.html?utm_source=preview&utm_medium=smoke&utm_campaign=honua-site-3`, accept analytics, click a contact CTA, and confirm hidden `lead_*` fields include UTM and CTA context before submitting.
+2. Declined-consent smoke: decline analytics and confirm the contact form remains submittable with blank `lead_*` fields.
+3. Intake smoke: submit a test lead through the approved test process and attach the FormSubmit or CRM receipt evidence.
+4. Downstream smoke: attach sales-owned evidence that the lead reached the CRM or tracked intake queue, owner assignment happened, and failed-sync alerting or missed-lead escalation is active.
+
+## Release-Lane Ownership
+
+- `honua-site#3`: site form contract, CTA instrumentation, consent-gated attribution, static validation, and this handoff evidence path.
+- `honua-sales`: CRM field mapping/import, lead owner, follow-up SLA, intake smoke evidence, and failed-sync alerting. If no existing sales ticket explicitly owns sync monitoring and failed-lead alerting, file a bounded sales child ticket for that work.
+- `honua-support`: missed-follow-up escalation routing if support owns pilot escalation.
+- `honua-marketplace#3`: marketplace URL, offer/listing package, entitlement activation proof, and publish evidence. The site should not add marketplace CTAs until those details are supplied.
+- `honua-site#9`: proof hub for benchmarks, compatibility matrix, migration evidence, and reference architecture.
+- `honua-site#17`: public claims matrix mapping site claims to source/proof/roadmap status.
+- `honua-showcase` and sales proof assets: repeatable portal-published dataset/demo flow for pilot and buyer-path motions.

--- a/index.html
+++ b/index.html
@@ -252,9 +252,74 @@
           <a class="btn btn-ghost" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">Browse GitHub</a>
         </div>
       </section>
+
+      <section id="contact" class="bed-contact" aria-labelledby="contact-title">
+        <div class="contact-grid">
+          <div class="contact-copy">
+            <span class="eyebrow">// talk to us</span>
+            <h2 id="contact-title">Tell us which workflows need continuity.</h2>
+            <p class="bed-lede">
+              Replacing ArcGIS or GeoServer. Moving apps to gRPC. Standing up GitOps for publishing.
+              Any of these is a fine first thread — or skip the form and
+              <a
+                class="text-link"
+                href="docs.html#quickstart"
+                data-analytics-event="cta_click"
+                data-analytics-label="home_contact_quickstart"
+                data-analytics-destination="docs.html#quickstart"
+              >launch the quickstart</a>.
+            </p>
+          </div>
+          <form
+            class="contact-form"
+            action="https://formsubmit.co/mike@honua.io"
+            method="POST"
+            data-contact-form
+            data-analytics-event="lead_form_submit"
+            data-analytics-label="home_contact_form"
+            data-analytics-destination="formsubmit"
+          >
+            <input type="hidden" name="_captcha" value="true" />
+            <input type="hidden" name="_subject" value="Honua.io migration assessment" />
+            <input type="hidden" name="lead_landing_page" value="" />
+            <input type="hidden" name="lead_current_page" value="" />
+            <input type="hidden" name="lead_referrer" value="" />
+            <input type="hidden" name="lead_utm_source" value="" />
+            <input type="hidden" name="lead_utm_medium" value="" />
+            <input type="hidden" name="lead_utm_campaign" value="" />
+            <input type="hidden" name="lead_utm_term" value="" />
+            <input type="hidden" name="lead_utm_content" value="" />
+            <input type="hidden" name="lead_cta_label" value="" />
+            <input type="hidden" name="lead_cta_page" value="" />
+            <input type="hidden" name="lead_cta_href" value="" />
+            <label>
+              Name
+              <input type="text" name="name" autocomplete="name" required />
+            </label>
+            <label>
+              Work Email
+              <input type="email" name="email" autocomplete="email" required />
+            </label>
+            <label>
+              Company
+              <input type="text" name="company" autocomplete="organization" />
+            </label>
+            <label>
+              What are you trying to ship?
+              <textarea
+                name="message"
+                rows="5"
+                placeholder="Replace ArcGIS Server, move off GeoServer, give AI tools access to parcels, add Git-based deployment, move apps to gRPC."
+                required
+              ></textarea>
+            </label>
+            <button class="btn btn-primary" type="submit">Send</button>
+          </form>
+        </div>
+      </section>
     </main>
 
-    <footer id="contact" class="bed-footer">
+    <footer class="bed-footer">
       <div class="footer-row">
         <div class="left">
           <img src="assets/honua-logo.svg" alt="" aria-hidden="true" />

--- a/index.html
+++ b/index.html
@@ -55,7 +55,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="home_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -77,7 +83,13 @@
             faster spatial services through the tools, APIs, and workflows they already use.
           </p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a
+              class="btn btn-primary"
+              href="#contact"
+              data-analytics-event="cta_click"
+              data-analytics-label="home_hero_contact"
+              data-analytics-destination="index.html#contact"
+            >Talk to us</a>
             <a class="btn btn-ghost" href="https://github.com/honua-io/honua-server#quick-start" target="_blank" rel="noopener noreferrer">$ docker compose up ↗</a>
             <span class="cta-meta">→ <a href="docs.html">docs</a> · <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">github</a> · <a href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">terraform</a></span>
           </div>
@@ -210,7 +222,13 @@
             <span class="b">Your whole GIS workflow with AI assistance — spatial analysis, map and report making, and DevOps. Same audit log as the rest of the platform.</span>
             <span class="more mono">READ</span>
           </a>
-          <a class="pillar pillar-call" href="mailto:info@honua.io">
+          <a
+            class="pillar pillar-call"
+            href="#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="home_pillars_contact"
+            data-analytics-destination="index.html#contact"
+          >
             <span class="n">+</span>
             <span class="t">Walkthrough with your stack</span>
             <span class="b">We'll point Honua at your ArcGIS / GeoServer setup and ship a pilot-scoped migration plan in two weeks.</span>
@@ -248,7 +266,13 @@
         <span class="eyebrow">// next</span>
         <h2>Compatible with your stack.<br /><span class="teal">Built for what's next.</span></h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="home_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">Browse GitHub</a>
         </div>
       </section>

--- a/interoperability.html
+++ b/interoperability.html
@@ -36,7 +36,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="interoperability_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -52,7 +58,13 @@
             contract and reshapes the infrastructure underneath.
           </p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a
+              class="btn btn-primary"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-analytics-label="interoperability_hero_contact"
+              data-analytics-destination="index.html#contact"
+            >Talk to us</a>
             <a class="btn btn-ghost" href="migration.html">Low risk migration →</a>
             <a class="btn btn-ghost" href="claims.html">Evidence ledger →</a>
           </div>
@@ -201,7 +213,13 @@
         <span class="eyebrow">// next</span>
         <h2>Drop Honua behind your existing clients.<br /><span class="teal">Migrate the apps at your pace.</span></h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="interoperability_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="migration.html">Low risk migration</a>
         </div>
       </section>

--- a/migration.html
+++ b/migration.html
@@ -36,7 +36,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="migration_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -52,7 +58,13 @@
             Your team doesn't write a migration project, they run one — in the language their app already uses.
           </p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a
+              class="btn btn-primary"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-analytics-label="migration_hero_contact"
+              data-analytics-destination="index.html#contact"
+            >Talk to us</a>
             <a class="btn btn-ghost" href="interoperability.html">Compatibility →</a>
           </div>
         </div>
@@ -329,7 +341,13 @@
         <span class="eyebrow">// next</span>
         <h2>Run the import. <span class="teal">Run the converter.</span><br />Ship a side-by-side rollout.</h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="migration_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="interoperability.html">Compatibility</a>
         </div>
       </section>

--- a/open-core.html
+++ b/open-core.html
@@ -36,7 +36,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="open_core_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -53,7 +59,13 @@
             as the capability baseline. Specific pricing follows once those tiers are real — not before.
           </p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="mailto:info@honua.io">Help shape the tiers</a>
+            <a
+              class="btn btn-primary"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-analytics-label="open_core_hero_help_shape"
+              data-analytics-destination="index.html#contact"
+            >Help shape the tiers</a>
             <a class="btn btn-ghost" href="cloud-native.html">Cloud-native →</a>
           </div>
         </div>
@@ -130,7 +142,13 @@
         <span class="eyebrow">// next</span>
         <h2>Help shape the<br /><span class="teal">commercial tiers.</span></h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="open_core_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="cloud-native.html">Cloud-native</a>
         </div>
       </section>

--- a/operations.html
+++ b/operations.html
@@ -36,7 +36,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="operations_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -53,7 +59,13 @@
             alerts, drafts the fix, and parks it for your team to merge.
           </p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a
+              class="btn btn-primary"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-analytics-label="operations_hero_contact"
+              data-analytics-destination="index.html#contact"
+            >Talk to us</a>
             <a class="btn btn-ghost" href="cloud-native.html">Cloud-native →</a>
           </div>
         </div>
@@ -228,7 +240,13 @@
         <span class="eyebrow">// next</span>
         <h2>Operate GIS<br /><span class="teal">like the rest of your stack.</span></h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="operations_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="cloud-native.html">Cloud-native</a>
         </div>
       </section>

--- a/performance.html
+++ b/performance.html
@@ -36,7 +36,13 @@
         <a href="performance.html" aria-current="page">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="performance_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 
@@ -52,7 +58,13 @@
             surface absorb the long tail — fast at any zoom, without hand-tuning a server pool.
           </p>
           <div class="cta-row">
-            <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a
+              class="btn btn-primary"
+              href="index.html#contact"
+              data-analytics-event="cta_click"
+              data-analytics-label="performance_hero_contact"
+              data-analytics-destination="index.html#contact"
+            >Talk to us</a>
             <a class="btn btn-ghost" href="https://github.com/honua-io/geobench" target="_blank" rel="noopener noreferrer">See benchmarks ↗</a>
           </div>
         </div>
@@ -139,7 +151,13 @@
         <span class="eyebrow">// next</span>
         <h2>Run the benchmarks<br /><span class="teal">against your own workload.</span></h2>
         <div class="row">
-          <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
+          <a
+            class="btn btn-primary"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="performance_cta_band_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
           <a class="btn btn-ghost" href="https://github.com/honua-io/geobench" target="_blank" rel="noopener noreferrer">See methodology ↗</a>
         </div>
       </section>

--- a/privacy.html
+++ b/privacy.html
@@ -33,7 +33,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="privacy_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 

--- a/scripts/validate-lead-capture.sh
+++ b/scripts/validate-lead-capture.sh
@@ -114,7 +114,7 @@ perl -0ne '
     next unless defined $href;
     next unless $href =~ /^(?:index\.html#contact|#contact|docs\.html#quickstart|#quickstart|pricing\.html)$/;
     my ($class) = $tag =~ /\bclass="([^"]*)"/;
-    next unless defined $class && $class =~ /(?:^|\s)(?:button|nav-utility)(?:\s|$)/;
+    next unless defined $class && $class =~ /(?:^|\s)(?:button|nav-utility|btn|nav-cta|pillar-call)(?:\s|$)/;
 
     my $expected_destination = $href;
     $expected_destination = "index.html#contact" if $href eq "#contact";

--- a/scripts/validate-lead-capture.sh
+++ b/scripts/validate-lead-capture.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+index_file="${repo_root}/index.html"
+analytics_file="${repo_root}/assets/analytics.js"
+headers_file="${repo_root}/_headers"
+handoff_doc="${repo_root}/docs/lead-capture-handoff.md"
+workflow_file="${repo_root}/.github/workflows/pages.yml"
+form_action="https://formsubmit.co/mike@honua.io"
+
+lead_fields=(
+  "lead_landing_page"
+  "lead_current_page"
+  "lead_referrer"
+  "lead_utm_source"
+  "lead_utm_medium"
+  "lead_utm_campaign"
+  "lead_utm_term"
+  "lead_utm_content"
+  "lead_cta_label"
+  "lead_cta_page"
+  "lead_cta_href"
+)
+
+fail() {
+  local message="$1"
+  echo "Validation failed: ${message}" >&2
+  exit 1
+}
+
+require_file() {
+  local file="$1"
+  [[ -f "${file}" ]] || fail "missing required file ${file}"
+}
+
+require_fixed() {
+  local needle="$1"
+  local file="$2"
+  grep -Fq "${needle}" "${file}" || fail "expected '${needle}' in ${file}"
+}
+
+require_match() {
+  local pattern="$1"
+  local file="$2"
+  grep -Eq "${pattern}" "${file}" || fail "expected pattern '${pattern}' in ${file}"
+}
+
+require_no_match() {
+  local pattern="$1"
+  local file="$2"
+  if grep -Eq "${pattern}" "${file}"; then
+    fail "unexpected pattern '${pattern}' in ${file}"
+  fi
+}
+
+require_file "${index_file}"
+require_file "${analytics_file}"
+require_file "${headers_file}"
+require_file "${handoff_doc}"
+require_file "${workflow_file}"
+
+form_tag="$(perl -0ne 'if (/(<form\b[^>]*data-contact-form[^>]*>)/s) { print $1; exit }' "${index_file}")"
+[[ -n "${form_tag}" ]] || fail "contact form is missing data-contact-form"
+
+case "${form_tag}" in
+  *"action=\"${form_action}\""*) ;;
+  *) fail "contact form action must stay ${form_action}" ;;
+esac
+
+case "${form_tag}" in
+  *'method="POST"'*) ;;
+  *) fail "contact form must submit with method=\"POST\"" ;;
+esac
+
+case "${form_tag}" in
+  *'data-analytics-event="lead_form_submit"'*) ;;
+  *) fail "contact form must emit lead_form_submit" ;;
+esac
+
+case "${form_tag}" in
+  *'data-analytics-destination="formsubmit"'*) ;;
+  *) fail "contact form must identify the FormSubmit destination" ;;
+esac
+
+for field in "${lead_fields[@]}"; do
+  require_match "<input[^>]*(name=\"${field}\"[^>]*type=\"hidden\"|type=\"hidden\"[^>]*name=\"${field}\")" "${index_file}"
+  require_fixed "\"${field}\"" "${analytics_file}"
+  require_fixed "\`${field}\`" "${handoff_doc}"
+done
+
+require_fixed "sendAnalyticsEvent(form.dataset.analyticsEvent || \"lead_form_submit\"" "${analytics_file}"
+require_fixed "page_location: currentPage()" "${analytics_file}"
+require_fixed "transport_type: \"beacon\"" "${analytics_file}"
+require_fixed "if (!hasAnalyticsConsent())" "${analytics_file}"
+require_fixed "clearContactAttribution(form)" "${analytics_file}"
+
+require_no_match "form\\.elements\\.(name|email|company|message)|lead_(name|email|company|message)|\\b(name|email|company|message)[[:space:]]*:" "${analytics_file}"
+
+require_match "Content-Security-Policy: .*form-action 'self' https://formsubmit\\.co" "${headers_file}"
+require_match "content=\".*form-action 'self' https://formsubmit\\.co" "${index_file}"
+require_fixed "${form_action}" "${handoff_doc}"
+require_fixed "Failed lead sync alerting" "${handoff_doc}"
+require_fixed "CRM field mapping/import" "${handoff_doc}"
+require_fixed "./scripts/validate-lead-capture.sh" "${workflow_file}"
+
+perl -0ne '
+  my $file = $ARGV;
+  my $html = $_;
+  while ($html =~ /<a\b[^>]*>/sg) {
+    my $tag = $&;
+    my $start = $-[0];
+    my ($href) = $tag =~ /\bhref="([^"]+)"/;
+    next unless defined $href;
+    next unless $href =~ /^(?:index\.html#contact|#contact|docs\.html#quickstart|#quickstart|pricing\.html)$/;
+    my ($class) = $tag =~ /\bclass="([^"]*)"/;
+    next unless defined $class && $class =~ /(?:^|\s)(?:button|nav-utility)(?:\s|$)/;
+
+    my $expected_destination = $href;
+    $expected_destination = "index.html#contact" if $href eq "#contact";
+    $expected_destination = "docs.html#quickstart" if $href eq "#quickstart";
+
+    my @missing;
+    push @missing, "data-analytics-event=\"cta_click\"" unless $tag =~ /\bdata-analytics-event="cta_click"/;
+    push @missing, "data-analytics-label" unless $tag =~ /\bdata-analytics-label="[^"]+"/;
+    push @missing, "data-analytics-destination=\"${expected_destination}\"" unless $tag =~ /\bdata-analytics-destination="\Q$expected_destination\E"/;
+
+    if (@missing) {
+      my $prefix = substr($html, 0, $start);
+      my $line = 1 + ($prefix =~ tr/\n//);
+      print STDERR "Validation failed: ${file}:${line} buyer-path CTA missing " . join(", ", @missing) . "\n";
+      exit 1;
+    }
+  }
+' "${repo_root}"/*.html
+
+echo "Lead capture validation passed."

--- a/security.html
+++ b/security.html
@@ -33,7 +33,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="security_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 

--- a/styles.css
+++ b/styles.css
@@ -376,6 +376,28 @@ img { max-width: 100%; height: auto; display: block; }
 .bed-cta-band .teal { color: var(--bed-teal); }
 .bed-cta-band .row { display: flex; gap: 10px; justify-content: center; margin-top: 28px; flex-wrap: wrap; }
 
+/* ── contact ─────────────────────────────────────────── */
+.bed-contact { padding: 96px 48px; border-top: 1px solid var(--bed-rule); background: var(--bed-bg); }
+.bed-contact .contact-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 48px; max-width: 1280px; margin: 0 auto; align-items: start; }
+.bed-contact .contact-copy h2 { font-size: 40px; font-weight: 600; letter-spacing: -0.02em; margin: 12px 0 18px; line-height: 1.1; color: var(--bed-text); }
+.bed-contact .contact-form { display: grid; gap: 14px; background: var(--bed-surface); border: 1px solid var(--bed-rule); border-radius: 10px; padding: 28px; }
+.bed-contact .contact-form label { display: grid; gap: 6px; font-family: "Geist Mono", monospace; font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--bed-text-dim); }
+.bed-contact .contact-form input,
+.bed-contact .contact-form textarea {
+  background: var(--bed-bg); color: var(--bed-text); border: 1px solid var(--bed-rule);
+  border-radius: 7px; padding: 10px 12px; font: inherit; font-family: "Geist", sans-serif;
+  letter-spacing: normal; text-transform: none;
+}
+.bed-contact .contact-form input:focus,
+.bed-contact .contact-form textarea:focus { outline: 2px solid var(--bed-teal); outline-offset: 1px; }
+.bed-contact .contact-form textarea { resize: vertical; min-height: 120px; }
+.bed-contact .contact-form button { justify-self: start; margin-top: 4px; }
+@media (max-width: 860px) {
+  .bed-contact { padding: 72px 24px; }
+  .bed-contact .contact-grid { grid-template-columns: 1fr; gap: 32px; }
+  .bed-contact .contact-copy h2 { font-size: 32px; }
+}
+
 /* ── footer ──────────────────────────────────────────── */
 .bed-footer { padding: 36px 48px; border-top: 1px solid var(--bed-rule); display: flex; flex-direction: column; gap: 22px; font-size: 12.5px; color: var(--bed-text-dim); background: var(--bed-bg); }
 .footer-row { display: flex; justify-content: space-between; align-items: center; gap: 24px; flex-wrap: wrap; }

--- a/terms.html
+++ b/terms.html
@@ -33,7 +33,13 @@
         <a href="performance.html">Performance</a>
         <a href="ai-gis.html">AI-ready</a>
         <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-        <a class="nav-cta" href="mailto:info@honua.io">Talk to us</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="terms_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
       </nav>
     </header>
 


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #3
## Summary

Lead capture instrumentation and CRM handoff (forms + attribution)
## Changes Made

- Lead capture instrumentation and CRM handoff (forms + attribution)
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [x] Documentation updated
- [ ] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
- Treated the two findings as one invariant family — "buyer-path CTAs must carry attribution before reaching the form" — and swept the bounded subsystem (every `*.html` page in the repo root, every `nav-cta` / `btn-primary` / `pillar-call` instance). All 13 kept HTML files were inspected; nav-cta CTAs fixed in all 13, hero/late-page `btn btn-primary` "Talk to us" CTAs fixed on 9 pages, `pillar pillar-call` fixed on index.html. Pages with only a nav CTA (docs.html, privacy.html, security.html, terms.html) and claims.html (no hero btn-primary in its redesign) were also covered.
- Pointed every off-homepage CTA at the absolute `index.html#contact` so cross-page navigation loads the form section directly; `assets/analytics.js:217-237` already selects both `a[href="index.html#contact"]` and `a[href="#contact"]`, so no analytics code change was needed.
- Used file-basename labels (`ai_gis_nav_contact`, `cloud_native_hero_contact`, etc.) so CRM filters can attribute leads back to the source page and section; kept the existing `home_*` prefix for index.html CTAs.
- Kept `open-core.html` hero label semantically distinct (`open_core_hero_help_shape`) because the copy reads "Help shape the tiers" rather than the generic "Talk to us".
- Considered also touching the footer `INFO@HONUA.IO` mailto links and the `bed-hero`/`bed-cta-band` `btn-ghost` links (GitHub/Terraform/docs/etc.). Left them alone: the footer email is a courtesy address-display, not a buyer CTA, and the btn-ghost destinations are off-site reference links — none of them are in the buyer-path destination set the validator enforces.
- Created a new commit (not amended) per the harness rule; the branch now has two commits on top of trunk and the merge stays clean.

Follow-ons:
- Pre-existing (unchanged from prior pass): `README.md` and `docs/features/README.md` still reference pages removed by the Bedrock redesign (`platform.html`, `sdks.html`, `mobile.html`, `agentic-gis.html`, `devops.html`, `runtime.html`, `protocols.html`, `modernization.html`, `pricing.html`). Pre-existing inconsistency on trunk; out of scope for this ticket.

Code kaizen:
Deferred 1 low-priority finding(s) to cleanup backlog. Primary contact CTA routing now goes through the form path; one validator coverage gap remains.
