### PR TITLE
[codex] launch minimal platform site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ Static site extracted from `honua-io/honua-server` (issue #336).
 Current site sections and operational features are summarized in [docs/features/README.md](docs/features/README.md).
 
 Repository layout:
-- `index.html` - homepage and contact form
+- `index.html` - minimal homepage and contact entry points
+- `cloud-native.html` - modern cloud-native platform proof points
+- `open-core.html` - open-core geoplatform and license boundary
+- `operations.html` - operator-focused deployment, GitOps, OTel, and AI DevOps
+- `interoperability.html` - standards, file, database, gRPC, and MCP compatibility
+- `performance.html` - performance architecture and GeoBench entry points
+- `ai-gis.html` - AI-ready GIS workflows and MCP surface
+- `migration.html` - easy adoption and migration paths
 - `platform.html` - platform overview
 - `protocols.html` - protocol surface and compatibility story
 - `sdks.html` - SDK and developer entry points

--- a/ai-gis.html
+++ b/ai-gis.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua | AI-Ready GIS</title>
+    <meta
+      name="description"
+      content="How Honua is AI-ready for spatial query, AI DevOps, analytics, report generation, app creation, cartography, and map making."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell minimal-shell">
+      <header class="topbar minimal-topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Modern GIS platform</span>
+          </div>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+        <nav class="nav-groups minimal-nav" aria-label="Primary">
+          <a class="nav-utility active" href="cloud-native.html">Platform</a>
+          <a class="nav-utility" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="mailto:info@honua.io">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Platform</p>
+          <h1>AI-ready GIS.</h1>
+          <p class="page-intro">
+            AI-ready means agents get structured, governed access to spatial data and operations without
+            scraping maps, guessing schemas, or inventing API calls.
+          </p>
+          <nav class="platform-nav" aria-label="Platform pages">
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="performance.html">Performance</a>
+            <a class="active" href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </nav>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Workflow support</p>
+            <h2>AI enablement across GIS work, not a chatbot beside it.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Workflow</th>
+                  <th>How Honua supports it</th>
+                  <th>Why it matters</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Workflow">Spatial query</td>
+                  <td data-label="How Honua supports it">Agents can inspect schemas, run filters, buffers, intersections, joins, and exports through structured tools.</td>
+                  <td data-label="Why it matters">Non-specialists can ask spatial questions while governed data and permissions stay intact.</td>
+                </tr>
+                <tr>
+                  <td data-label="Workflow">AI DevOps</td>
+                  <td data-label="How Honua supports it">Operational agents can read deploy status, logs, traces, config, and runbook actions.</td>
+                  <td data-label="Why it matters">Operators get help diagnosing routine incidents without bypassing review.</td>
+                </tr>
+                <tr>
+                  <td data-label="Workflow">Analytics and reports</td>
+                  <td data-label="How Honua supports it">Agents can combine spatial queries, summaries, tables, maps, citations, and exports into repeatable reports.</td>
+                  <td data-label="Why it matters">GIS teams spend less time assembling routine outputs and more time reviewing analysis quality.</td>
+                </tr>
+                <tr>
+                  <td data-label="Workflow">App creation</td>
+                  <td data-label="How Honua supports it">Typed SDKs, live schemas, and service metadata give agents the inputs needed to generate spatial apps.</td>
+                  <td data-label="Why it matters">Developers can turn governed spatial services into usable applications faster.</td>
+                </tr>
+                <tr>
+                  <td data-label="Workflow">Cartography and map making</td>
+                  <td data-label="How Honua supports it">Agents can use layers, styles, legends, filters, and layout context as explicit platform objects.</td>
+                  <td data-label="Why it matters">Map production becomes more accessible while GIS leads retain standards and review.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Protocol surface</p>
+            <h2>MCP is the agent boundary.</h2>
+            <p class="section-copy">
+              The agent surface is exposed as schemas, tools, permissions, audit logs, and examples.
+              That separates AI-ready GIS from prompts pasted on top of a legacy API.
+            </p>
+          </div>
+          <div class="detail-grid">
+            <article class="detail-card detail-card-accent">
+              <p class="card-kicker">MCP</p>
+              <h3>Agent-readable collections, schemas, tools, and operations.</h3>
+              <p>
+                The MCP path gives agents a structured interface to governed spatial data.
+                <a class="text-link" href="https://github.com/honua-io/geospatial-mcp" target="_blank" rel="noopener noreferrer">See the MCP schema</a>.
+              </p>
+            </article>
+            <article class="detail-card detail-card-spot">
+              <p class="card-kicker">gRPC and SDKs</p>
+              <h3>Typed APIs for generated apps and workflow automation.</h3>
+              <p>
+                App-making agents need reliable contracts. Honua exposes those through gRPC and SDKs.
+                <a class="text-link" href="https://github.com/honua-io/geospatial-grpc" target="_blank" rel="noopener noreferrer">See the gRPC schema</a>.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>Inspect the agent interface.</h2>
+          <p>Agent workflows are easiest to evaluate with tool-call traces, generated outputs, and audit logs.</p>
+          <div class="action-row">
+            <a class="button button-primary" href="https://github.com/honua-io/geospatial-mcp" target="_blank" rel="noopener noreferrer">MCP repo</a>
+            <a class="button button-secondary" href="https://github.com/honua-io/geospatial-grpc" target="_blank" rel="noopener noreferrer">gRPC repo</a>
+            <a class="button button-ghost" href="index.html">Home</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer minimal-footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <a href="index.html">Home</a>
+            <a href="mailto:info@honua.io">Contact</a>
+          </div>
+          <div>
+            <p class="footer-title">Platform</p>
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+          </div>
+          <div>
+            <p class="footer-title">More</p>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="performance.html">Performance</a>
+            <a href="migration.html">Adoption</a>
+          </div>
+          <div>
+            <p class="footer-title">Contact</p>
+            <a href="mailto:info@honua.io">Email</a>
+            <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/cloud-native.html
+++ b/cloud-native.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua | Modern Cloud-Native</title>
+    <meta
+      name="description"
+      content="How Honua is a modern cloud-native geospatial platform: containers, serverless, Kubernetes, cloud primitives, Terraform, OIDC, autoscaling, and marketplace delivery."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell minimal-shell">
+      <header class="topbar minimal-topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Modern GIS platform</span>
+          </div>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+        <nav class="nav-groups minimal-nav" aria-label="Primary">
+          <a class="nav-utility active" href="cloud-native.html">Platform</a>
+          <a class="nav-utility" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="mailto:info@honua.io">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Platform</p>
+          <h1>Modern cloud-native.</h1>
+          <p class="page-intro">
+            Honua is designed to run on the same infrastructure patterns as modern application services:
+            containers, serverless, Kubernetes, object storage, managed identity, repeatable delivery, and
+            elastic scale.
+          </p>
+          <nav class="platform-nav" aria-label="Platform pages">
+            <a class="active" href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </nav>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Capabilities</p>
+            <h2>Cloud-native means deployable, composable, and elastic.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Capability</th>
+                  <th>How Honua supports it</th>
+                  <th>Reference</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Capability">Runs across common cloud runtimes</td>
+                  <td data-label="How Honua supports it">AWS ECS/Fargate, AWS Lambda, AWS EKS, Azure Container Apps, Azure Functions, and Azure AKS are the supported target set.</td>
+                  <td data-label="Reference"><a class="text-link" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">Terraform modules</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Capability">Uses cloud primitives</td>
+                  <td data-label="How Honua supports it">Object storage, batch jobs, load balancers, Kubernetes, Redis, autoscaling, and managed networking are first-class deployment concerns.</td>
+                  <td data-label="Reference"><a class="text-link" href="operations.html">Operations</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Capability">Supports modern identity</td>
+                  <td data-label="How Honua supports it">OIDC is the identity boundary for enterprise deployment, with external identity providers and SSO fitting the same model.</td>
+                  <td data-label="Reference">OIDC and SSO fit the same deployment model.</td>
+                </tr>
+                <tr>
+                  <td data-label="Capability">Ships through modern delivery paths</td>
+                  <td data-label="How Honua supports it">Terraform, GitOps workflows, and cloud marketplace offerings are part of the delivery model.</td>
+                  <td data-label="Reference"><a class="text-link" href="operations.html">Operations</a>.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>See how it is operated.</h2>
+          <p>Cloud-native architecture matters when operators can deploy, observe, scale, and update it without special GIS infrastructure.</p>
+          <div class="action-row">
+            <a class="button button-primary" href="operations.html">Operations</a>
+            <a class="button button-secondary" href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">Terraform</a>
+            <a class="button button-ghost" href="index.html">Home</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer minimal-footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <a href="index.html">Home</a>
+            <a href="mailto:info@honua.io">Contact</a>
+          </div>
+          <div>
+            <p class="footer-title">Platform</p>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+            <a href="interoperability.html">Interoperability</a>
+          </div>
+          <div>
+            <p class="footer-title">More</p>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </div>
+          <div>
+            <p class="footer-title">Contact</p>
+            <a href="mailto:info@honua.io">Email</a>
+            <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,25 +3,25 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Honua | One geospatial foundation for every team</title>
+    <title>Honua | Cloud-native open-core geoplatform</title>
     <meta
       name="description"
-      content="Honua is a Preview geospatial foundation for analysts, developers, platform teams, and AI agents, with documented OGC counts and ArcGIS/GeoServer compatibility paths that call out partial-parity caveats."
+      content="Honua is a modern cloud-native open-core geoplatform built to be easy to operate, broadly interoperable, high performance, AI-ready, and easy to adopt."
     />
-    <meta property="og:title" content="Honua | One geospatial foundation for every team" />
+    <meta property="og:title" content="Honua | Cloud-native open-core geoplatform" />
     <meta
       property="og:description"
-      content="A Preview geospatial foundation with documented compatibility paths, source-backed counts, and visible partial-parity caveats."
+      content="Spatial infrastructure that runs like normal software: lower cost, less operational burden, faster GIS delivery, and better user experience."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://honua.io" />
     <meta property="og:image" content="https://honua.io/assets/og-image.png" />
     <meta property="og:image:alt" content="Honua logo on a dark technical background" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Honua | One geospatial foundation for every team" />
+    <meta name="twitter:title" content="Honua | Cloud-native open-core geoplatform" />
     <meta
       name="twitter:description"
-      content="Preview geospatial foundation with documented compatibility paths and partial-parity caveats."
+      content="Modern cloud-native, open-core GIS platform for software teams."
     />
     <meta name="twitter:image" content="https://honua.io/assets/og-image.png" />
     <meta
@@ -36,562 +36,116 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="site-shell">
-      <header class="topbar">
+    <div class="site-shell minimal-shell">
+      <header class="topbar minimal-topbar">
         <a class="brand" href="index.html" aria-label="Honua home">
           <img src="assets/honua-logo.png" alt="Honua logo" />
           <div>
             <span class="brand-name">Honua</span>
-            <span class="brand-tag">One foundation · Every user</span>
+            <span class="brand-tag">Modern GIS platform</span>
           </div>
         </a>
         <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
-        <nav class="nav-groups" aria-label="Primary">
-          <div class="nav-group">
-            <a class="nav-group-title active" href="platform.html">Platform</a>
-            <div class="nav-subnav">
-              <a href="agentic-gis.html">AI Agents</a>
-              <a href="runtime.html">gRPC Runtime</a>
-              <a href="devops.html">GitOps + OTel</a>
-            </div>
-          </div>
-          <div class="nav-group">
-            <a class="nav-group-title" href="docs.html">Developers</a>
-            <div class="nav-subnav">
-              <a href="docs.html">Docs</a>
-              <a href="sdks.html">SDKs</a>
-              <a href="mobile.html">Field Toolkit</a>
-            </div>
-          </div>
-          <div class="nav-group">
-            <a class="nav-group-title" href="protocols.html">Compatibility</a>
-            <div class="nav-subnav">
-              <a href="protocols.html">Standards &amp; Conformance</a>
-              <a href="modernization.html#arcgis-geoserver">ArcGIS + GeoServer</a>
-            </div>
-          </div>
-          <a class="nav-utility" href="modernization.html">Modernize</a>
-          <a class="nav-utility" href="pricing.html">Open Core</a>
-          <a class="nav-utility" href="https://github.com/honua-io/honua-server" target="_blank" rel="noopener noreferrer">GitHub</a>
-          <a
-            class="button button-nav"
-            href="#contact"
-            data-analytics-event="cta_click"
-            data-analytics-label="home_nav_contact"
-            data-analytics-destination="index.html#contact"
-          >Talk to us</a>
+        <nav class="nav-groups minimal-nav" aria-label="Primary">
+          <a class="nav-utility" href="cloud-native.html">Platform</a>
+          <a class="nav-utility" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="#contact">Contact</a>
         </nav>
       </header>
 
       <main>
-        <section class="hero hero-home">
-          <div class="hero-copy">
-            <p class="eyebrow">Platform · 2026</p>
-            <h1>One foundation for every way your team works with spatial data.</h1>
-            <p class="lede lede-beats">
-              <span>Ask in English.</span><span>Build in your language.</span><span>Deploy like software.</span>
-            </p>
-            <p class="lede">
-              Honua is one platform for the analysts who know the data, the teammates who need the answers,
-              the developers building spatial apps, the platform engineers deploying the stack, and the AI agents
-              already asking.
-            </p>
-            <div class="action-row">
-              <a
-                class="button button-primary"
-                href="docs.html#quickstart"
-                data-analytics-event="cta_click"
-                data-analytics-label="home_hero_quickstart"
-                data-analytics-destination="docs.html#quickstart"
-              >Launch the quickstart</a>
-              <a class="button button-secondary" href="sdks.html">See the SDKs</a>
-              <a class="button button-ghost" href="#why-now">Why now</a>
-            </div>
-            <div class="proof-row" aria-label="Platform proof points">
-              <span class="proof-pill">OGC API Features 137/137</span>
-              <span class="proof-pill">gRPC native</span>
-              <span class="proof-pill">6 targeted paths</span>
-              <span class="proof-pill">MCP preview</span>
-            </div>
-          </div>
-
-          <aside class="chat-demo" aria-label="Example conversation">
-            <header class="chat-header">
-              <span class="chat-dot"></span>
-              <span class="chat-title">honua · session #4721</span>
-              <span class="chat-meta">live gRPC</span>
-            </header>
-            <ol class="chat-log">
-              <li class="chat-turn chat-user">
-                <span class="chat-role">you</span>
-                <p>Show parcels rezoned in the last 90 days within 500m of the transit corridor.</p>
-              </li>
-              <li class="chat-turn chat-honua">
-                <span class="chat-role">honua</span>
-                <p class="chat-plan">
-                  Joining <code>parcels</code> to <code>zoning_changes</code>,
-                  filtering <code>changed_at &gt;= 2026-01-19</code>,
-                  intersecting a 500m buffer of <code>transit_corridor</code>.
-                </p>
-                <div class="chat-artifact">
-                  <div class="chat-artifact-bar">
-                    <span>47 features · 124&thinsp;ms · gRPC</span>
-                    <span class="chat-artifact-tag">live</span>
-                  </div>
-                  <div class="chat-map" aria-hidden="true">
-                    <div class="chat-map-bbox"></div>
-                    <div class="chat-map-corridor"></div>
-                    <span class="chat-map-dot" style="--x:18%;--y:40%"></span>
-                    <span class="chat-map-dot" style="--x:30%;--y:58%"></span>
-                    <span class="chat-map-dot" style="--x:41%;--y:33%"></span>
-                    <span class="chat-map-dot" style="--x:52%;--y:62%"></span>
-                    <span class="chat-map-dot" style="--x:61%;--y:44%"></span>
-                    <span class="chat-map-dot" style="--x:72%;--y:55%"></span>
-                    <span class="chat-map-dot chat-map-dot-hot" style="--x:46%;--y:48%"></span>
-                  </div>
-                </div>
-              </li>
-              <li class="chat-turn chat-user">
-                <span class="chat-role">you</span>
-                <p>Export as GeoJSON and open a PR against the parcels-feed repo.</p>
-              </li>
-              <li class="chat-turn chat-honua">
-                <span class="chat-role">honua</span>
-                <p class="chat-plan">
-                  <span class="chat-tick">✓</span> PR <a href="#" class="chat-link">#218</a> opened · <code>/exports/parcels-rezoned-2026q1.json</code>
-                </p>
-              </li>
-            </ol>
-          </aside>
-        </section>
-
-        <section class="section ticker-section" aria-hidden="true">
-          <div class="ticker-track">
-            <span class="ticker-item">OGC API Features</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">gRPC + Protobuf</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">ArcGIS compat</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">GeoServer compat</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">MCP for agents</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">PostGIS native</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">Field toolkit beta</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">OpenTelemetry</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">Open core · no seats</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">OGC API Features</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">gRPC + Protobuf</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">ArcGIS compat</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">GeoServer compat</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">MCP for agents</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">PostGIS native</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">Field toolkit beta</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">OpenTelemetry</span><span class="ticker-sep">·</span>
-            <span class="ticker-item">Open core · no seats</span><span class="ticker-sep">·</span>
-          </div>
-        </section>
-
-        <section class="section" id="why-now">
-          <div class="section-heading">
-            <p class="eyebrow">Why now</p>
-            <h2>Spatial data used to live with the GIS team. Now every team is a spatial team.</h2>
-            <p class="section-copy">
-              Policy wants answers. Product wants maps. Operations wants routing. Field wants pilot-ready mobile workflows.
-              Support wants territory views. Developers want typed SDKs. Platform engineers want something
-              that runs on Kubernetes. AI agents want a protocol. None of today's tools were built to serve
-              all of them at once. Honua is.
-            </p>
-          </div>
-        </section>
-
-        <section class="section section-contrast" id="who-its-for">
-          <div class="section-heading">
-            <p class="eyebrow">Who Honua is for</p>
-            <h2>Five user classes. One foundation.</h2>
-            <p class="section-copy">
-              Spatial work isn't a single job anymore. Honua gives every role — specialist and non-specialist
-              alike — a first-class way in.
-            </p>
-          </div>
-          <div class="persona-grid">
-            <article class="persona persona-wide">
-              <p class="card-kicker">01 · GIS Analysts &amp; Leads</p>
-              <h3>Offload the routine. Own the hard work.</h3>
-              <p>
-                Your ArcGIS Pro, QGIS, and GeoServer workflows stay on documented compatibility paths.
-                Agents and automation take the repetitive queries off your plate so you can spend your time on
-                the spatial analysis, data stewardship, and domain judgement only you can do. Honua is built to
-                make you the highest-leverage role in the room — not to work around you.
-              </p>
-            </article>
-            <article class="persona">
-              <p class="card-kicker">02 · Non-GIS Teammates</p>
-              <h3>Ask the question. Get the answer.</h3>
-              <p>
-                Planners, councilors, operators, support leads — ask what parcels shifted, what routes miss
-                coverage, which sites failed inspection. No license required, no ticket to file.
-              </p>
-            </article>
-            <article class="persona">
-              <p class="card-kicker">03 · Developers</p>
-              <h3>Typed contracts in your language.</h3>
-              <p>
-                JavaScript, Python, and .NET preview clients use gRPC under the hood. MAUI field workflows
-                remain Beta and pilot-scoped until field proof assets are linked.
-              </p>
-            </article>
-            <article class="persona">
-              <p class="card-kicker">04 · Platform Engineers</p>
-              <h3>A GIS that ships like your other services.</h3>
-              <p>
-                Services defined in Git. Rollouts reviewed in PRs. OpenTelemetry traces through the runtime
-                into PostGIS. Six deployment paths are tracked for Preview validation on AWS and Azure.
-              </p>
-            </article>
-            <article class="persona">
-              <p class="card-kicker">05 · AI Agents</p>
-              <h3>A protocol, not a parser.</h3>
-              <p>
-                MCP-native discovery, schema inspection, filtered queries, and bounded spatial tools. Claude,
-                GPT, Cursor, or your own agent can evaluate the protocol without ad hoc REST wrappers.
-              </p>
-            </article>
-          </div>
-        </section>
-
-        <section class="section" id="pillar-agents">
-          <div class="section-heading">
-            <p class="eyebrow">01 · Talk to your data</p>
-            <h2>Give every role access. Give your analyst leverage.</h2>
-            <p class="section-copy">
-              Honua exposes MCP-native discovery, schema inspection, filtered queries, and bounded spatial
-              tools for agent workflows. Claude, GPT, Cursor, or your own agent can evaluate the protocol.
-              Non-specialists can self-serve scoped questions they used to queue. Analysts offload routine
-              discovery and focus on the analysis that needs their judgement.
-            </p>
-          </div>
-          <div class="detail-grid">
-            <article class="detail-card">
-              <p class="card-kicker">Spatial join</p>
-              <p>"Find storefronts within walking distance of the new light rail stops, grouped by zoning category."</p>
-            </article>
-            <article class="detail-card">
-              <p class="card-kicker">Temporal</p>
-              <p>"What inspections failed in District 4 last quarter, and how did their re-check rate compare to District 3?"</p>
-            </article>
-            <article class="detail-card">
-              <p class="card-kicker">Edits</p>
-              <p>"Merge these three parcels, flag the conservation overlay, and queue a change request for review."</p>
-            </article>
-            <article class="detail-card">
-              <p class="card-kicker">Rendering</p>
-              <p>"Make a map for the council packet — parcels shaded by density, roads muted, no labels."</p>
-            </article>
-          </div>
+        <section class="page-hero minimal-home">
+          <p class="eyebrow">Honua</p>
+          <h1>Spatial infrastructure for modern software teams.</h1>
+          <p class="home-statement">
+            Honua is a <a href="cloud-native.html">modern cloud-native</a>
+            <a href="open-core.html">open-core geoplatform</a> built to be
+            <a href="operations.html">easy to operate</a>,
+            <a href="interoperability.html">broadly interoperable</a>,
+            <a href="performance.html">high performance</a>,
+            <a href="ai-gis.html">AI-ready</a>, and
+            <a href="migration.html">easy to adopt</a>.<br />
+            It helps organizations lower cloud, operations, and licensing costs while increasing the
+            throughput of GIS work.<br />
+            Teams can migrate
+            incrementally, run efficiently on modern infrastructure, and deliver maps, apps, analysis, and
+            reports faster.<br />
+            For users, the result is spatial software that is easier to access, quicker to
+            respond, and better aligned with the way they already work.
+          </p>
           <div class="action-row">
-            <a class="text-link" href="agentic-gis.html">See the agent interface →</a>
+            <a class="button button-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a class="button button-secondary" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">Browse GitHub</a>
+            <a class="button button-ghost" href="cloud-native.html">Explore the platform</a>
           </div>
         </section>
 
-        <section class="section section-contrast" id="pillar-sdks">
+        <section class="section comparison-section" aria-labelledby="comparison-title">
           <div class="section-heading">
-            <p class="eyebrow">02 · SDKs for everything</p>
-            <h2>Your developers ship in the language they already use.</h2>
-            <p class="section-copy">
-              Typed contracts for Preview application paths and Beta field workflows. Pick the client surface
-              that fits the team and the job, then check the claims matrix for release status.
-            </p>
+            <p class="eyebrow">Modern vs legacy GIS</p>
+            <h2 id="comparison-title">The difference is the operating model.</h2>
           </div>
-          <div class="sdk-grid">
-            <article class="sdk">
-              <header>
-                <span class="sdk-lang">JavaScript</span>
-                <span class="sdk-use">web · node</span>
-              </header>
-              <pre><code>import { HonuaClient } from "@honua/sdk";
-
-const c = new HonuaClient("https://gis.example.com");
-const parcels = await c.features("parcels").query({
-  where: "status = 'active'",
-  bbox: [-122.42, 37.77, -122.40, 37.79],
-});</code></pre>
-            </article>
-            <article class="sdk">
-              <header>
-                <span class="sdk-lang">Python</span>
-                <span class="sdk-use">analysis · pipelines</span>
-              </header>
-              <pre><code>from honua import Client
-
-with Client("https://gis.example.com") as c:
-    parcels = c.features("parcels").query(
-        where="status = 'active'",
-        bbox=(-122.42, 37.77, -122.40, 37.79),
-    )</code></pre>
-            </article>
-            <article class="sdk">
-              <header>
-                <span class="sdk-lang">.NET</span>
-                <span class="sdk-use">services · desktop</span>
-              </header>
-              <pre><code>using Honua;
-
-await using var c = new HonuaClient("https://gis.example.com");
-var parcels = await c.Features("parcels")
-    .Where("status = 'active'")
-    .InBbox(-122.42, 37.77, -122.40, 37.79)
-    .ToListAsync();</code></pre>
-            </article>
-            <article class="sdk">
-              <header>
-                <span class="sdk-lang">MAUI</span>
-                <span class="sdk-use">field beta</span>
-              </header>
-              <pre><code>// beta field collection
-var local = await MobileStore.OpenAsync("survey");
-await local.Features("inspections")
-           .UpsertAsync(reading);
-await local.SyncWhenOnline();</code></pre>
-            </article>
-          </div>
-          <div class="action-row">
-            <a class="text-link" href="sdks.html">Browse SDKs →</a>
-            <a class="text-link" href="mobile.html">Field toolkit →</a>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Legacy GIS</th>
+                  <th>Modern GIS platform</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Legacy GIS">Specialized servers, manual administration, and GIS-specific deployment workflows.</td>
+                  <td data-label="Modern GIS platform">Containers, Terraform, GitOps, cloud marketplaces, OIDC, autoscaling, and OpenTelemetry.</td>
+                </tr>
+                <tr>
+                  <td data-label="Legacy GIS">High switching costs because services, apps, clients, and data formats are tightly coupled.</td>
+                  <td data-label="Modern GIS platform">Standards, service importers, SDK migration helpers, and side-by-side adoption paths.</td>
+                </tr>
+                <tr>
+                  <td data-label="Legacy GIS">GIS work queues up behind scarce specialists and heavyweight tooling.</td>
+                  <td data-label="Modern GIS platform">Developers, analysts, operators, and AI agents all work against the same governed spatial foundation.</td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </section>
 
-        <section class="section" id="pillar-runtime">
+        <section class="section platform-index" aria-labelledby="platform-title">
           <div class="section-heading">
-            <p class="eyebrow">03 · Cloud-native runtime</p>
-            <h2>Runs where your other services already run.</h2>
-            <p class="section-copy">
-              gRPC under the hood, HTTP where it has to be. One binary targets the compute your team already
-              standardized on, with AWS and Azure validation evidence tracked outside this site.
-            </p>
+            <p class="eyebrow">Platform</p>
+            <h2 id="platform-title">How Honua is built.</h2>
           </div>
-          <div class="deploy-grid">
-            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">ECS / Fargate</span><span class="deploy-status">targeted</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">Lambda</span><span class="deploy-status">targeted</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">AWS</span><span class="deploy-target">EKS</span><span class="deploy-status">targeted</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">Container Apps</span><span class="deploy-status">targeted</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">Functions</span><span class="deploy-status">targeted</span></article>
-            <article class="deploy-cell"><span class="deploy-cloud">Azure</span><span class="deploy-target">AKS</span><span class="deploy-status">targeted</span></article>
-          </div>
-          <div class="action-row">
-            <a class="text-link" href="runtime.html">See the runtime →</a>
-          </div>
-        </section>
-
-        <section class="section section-contrast" id="pillar-standards">
-          <div class="section-heading">
-            <p class="eyebrow">04 · Standards, everywhere</p>
-            <h2>Your ArcGIS and GeoServer clients have compatibility paths.</h2>
-            <p class="section-copy">
-              Standards are how most of your team still does its best work. OGC API Features, WFS, WMS,
-              WMTS, GeoServices REST, GeoPackage, STAC, COG, and MVT stay framed by the documented
-              compatibility evidence and partial-parity caveats.
-            </p>
-          </div>
-          <div class="conformance">
-            <div class="conf-number">
-              <span class="conf-pair"><strong>137</strong><em>/137</em></span>
-              <span class="conf-caption">OGC API Features tests passing</span>
-            </div>
-            <ul class="standards-list">
-              <li>OGC API Features</li>
-              <li>WFS 2.0</li>
-              <li>WMS 1.3.0</li>
-              <li>WMTS 1.0</li>
-              <li>GeoServices REST</li>
-              <li>ArcGIS compat</li>
-              <li>GeoServer compat</li>
-              <li>PostGIS native</li>
-              <li>GeoPackage</li>
-              <li>STAC</li>
-              <li>COG</li>
-              <li>Mapbox Vector Tiles</li>
-              <li>Protobuf / gRPC</li>
-              <li>MCP</li>
-            </ul>
-          </div>
-          <div class="action-row">
-            <a class="text-link" href="protocols.html">Read the OGC submission →</a>
-          </div>
-        </section>
-
-        <section class="section" id="pillar-ops">
-          <div class="section-heading">
-            <p class="eyebrow">05 · Operate like software</p>
-            <h2>Run GIS the way you run the rest of your infrastructure.</h2>
-            <p class="section-copy">
-              Services defined in Git. Rollouts reviewed in PRs. Traces that reach from the edge into PostGIS.
-              AI DevOps workflows remain framed as repo-backed automation, not a support commitment.
-            </p>
-          </div>
-          <div class="card-grid card-grid-three">
-            <article class="card">
-              <p class="card-kicker">GitOps</p>
-              <h3>Services as manifests.</h3>
-              <p>Publish layers, feature services, and styling from YAML in a repo. Review changes in PRs. Roll back with <code class="inline-code">git revert</code>.</p>
-            </article>
-            <article class="card">
-              <p class="card-kicker">OpenTelemetry</p>
-              <h3>Traces through the whole stack.</h3>
-              <p>One trace from client, through the runtime, into PostGIS. Plug into the dashboards you already run — Grafana, Datadog, Honeycomb.</p>
-            </article>
-            <article class="card">
-              <p class="card-kicker">AI DevOps</p>
-              <h3>Automation that proposes fixes.</h3>
-              <p>Watches logs, summarizes issues, and proposes pull requests where repo evidence supports the workflow. Your team reviews the change.</p>
-            </article>
-          </div>
-          <div class="action-row">
-            <a class="text-link" href="devops.html">See operations →</a>
-          </div>
-        </section>
-
-        <section class="section">
-          <div class="section-heading">
-            <p class="eyebrow">If you're coming from ArcGIS or GeoServer</p>
-            <h2>Your existing stack gets a continuity plan while you build what's next.</h2>
-            <p class="section-copy">
-              Service importers, parity checks, and reconciliation are pilot-scoped until migration proof
-              assets are linked. Keep legacy clients on documented compatibility paths while new work
-              moves toward gRPC, SDKs, and agents.
-            </p>
-          </div>
-          <div class="callout">
-            Compatibility buys you time. What you build with that time — agents, SDKs, GitOps, telemetry — is the point.
-          </div>
-          <div class="action-row">
-            <a class="text-link" href="modernization.html">The modernization path →</a>
-          </div>
-        </section>
-
-        <section id="contact" class="section contact-section">
-          <div class="contact-grid">
-            <div class="contact-copy">
-              <p class="eyebrow">Start a conversation</p>
-              <h2>Tell us which workflows need continuity and what you want to improve.</h2>
-              <p>
-                Replacing ArcGIS or GeoServer. Moving apps to gRPC. Giving agents safe access to spatial data.
-                Standing up GitOps for publishing. Any of these is a fine first thread — or skip the form and
-                <a
-                  class="text-link"
-                  href="docs.html#quickstart"
-                  data-analytics-event="cta_click"
-                  data-analytics-label="home_contact_quickstart"
-                  data-analytics-destination="docs.html#quickstart"
-                >launch the quickstart</a>.
-              </p>
-              <div class="contact-points">
-                <span>ArcGIS and GeoServer replacement</span>
-                <span>Application migration automation</span>
-                <span>AI and agent workflows</span>
-                <span>Deployment and rollout planning</span>
-              </div>
-            </div>
-            <form
-              class="contact-form"
-              action="https://formsubmit.co/mike@honua.io"
-              method="POST"
-              data-contact-form
-              data-analytics-event="lead_form_submit"
-              data-analytics-label="home_contact_form"
-              data-analytics-destination="formsubmit"
-            >
-              <input type="hidden" name="_captcha" value="true" />
-              <input type="hidden" name="_subject" value="Honua.io migration assessment" />
-              <input type="hidden" name="lead_landing_page" value="" />
-              <input type="hidden" name="lead_current_page" value="" />
-              <input type="hidden" name="lead_referrer" value="" />
-              <input type="hidden" name="lead_utm_source" value="" />
-              <input type="hidden" name="lead_utm_medium" value="" />
-              <input type="hidden" name="lead_utm_campaign" value="" />
-              <input type="hidden" name="lead_utm_term" value="" />
-              <input type="hidden" name="lead_utm_content" value="" />
-              <input type="hidden" name="lead_cta_label" value="" />
-              <input type="hidden" name="lead_cta_page" value="" />
-              <input type="hidden" name="lead_cta_href" value="" />
-              <label>
-                Name
-                <input type="text" name="name" autocomplete="name" required />
-              </label>
-              <label>
-                Work Email
-                <input type="email" name="email" autocomplete="email" required />
-              </label>
-              <label>
-                Company
-                <input type="text" name="company" autocomplete="organization" />
-              </label>
-              <label>
-                What are you trying to ship?
-                <textarea
-                  name="message"
-                  rows="6"
-                  placeholder="Examples: replace ArcGIS Server, move off GeoServer, give AI tools access to parcels, add Git-based deployment, move apps to gRPC."
-                  required
-                ></textarea>
-              </label>
-              <button class="button button-primary" type="submit">Send</button>
-            </form>
+          <div class="platform-link-grid">
+            <a href="cloud-native.html">Modern cloud-native</a>
+            <a href="open-core.html">Open-core geoplatform</a>
+            <a href="operations.html">Easy to operate</a>
+            <a href="interoperability.html">Broadly interoperable</a>
+            <a href="performance.html">High performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Easy to adopt</a>
           </div>
         </section>
       </main>
 
-      <footer class="footer">
-        <div class="footer-band">
-          <div>
-            <p class="eyebrow">Build the next layer</p>
-            <h2>One foundation. Every way your team works with spatial data.</h2>
-            <p class="footer-copy">
-              Honua gives every role on your team — analyst, teammate, developer, platform engineer, agent —
-              a shared foundation for spatial work.
-            </p>
-          </div>
-          <div class="footer-actions">
-            <a
-              class="button button-primary"
-              href="docs.html#quickstart"
-              data-analytics-event="cta_click"
-              data-analytics-label="home_footer_quickstart"
-              data-analytics-destination="docs.html#quickstart"
-            >Launch the quickstart</a>
-            <a class="button button-secondary" href="protocols.html">OGC submission</a>
-            <a
-              class="button button-ghost"
-              href="#contact"
-              data-analytics-event="cta_click"
-              data-analytics-label="home_footer_contact"
-              data-analytics-destination="index.html#contact"
-            >Talk to us</a>
-          </div>
-        </div>
+      <footer id="contact" class="footer minimal-footer">
         <div class="footer-grid">
           <div>
-            <p class="footer-title">Honua</p>
-            <p class="footer-copy">One geospatial foundation for every way your team works with spatial data.</p>
+            <p class="footer-title">Contact</p>
+            <a href="mailto:info@honua.io">info@honua.io</a>
+            <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
           </div>
           <div>
             <p class="footer-title">Platform</p>
-            <a href="platform.html">Platform Overview</a>
-            <a href="agentic-gis.html">AI Agents</a>
-            <a href="runtime.html">gRPC Runtime</a>
-            <a href="devops.html">GitOps + OTel</a>
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="migration.html">Migration</a>
           </div>
           <div>
-            <p class="footer-title">Build</p>
-            <a href="modernization.html">Modernization</a>
-            <a href="docs.html">Documentation</a>
-            <a href="sdks.html">SDKs</a>
-            <a href="mobile.html">Field Toolkit</a>
-          </div>
-          <div>
-            <p class="footer-title">Trust</p>
-            <a href="protocols.html">Compatibility</a>
-            <a href="pricing.html">Open Core</a>
-            <a href="claims.html">Claims Matrix</a>
-            <a href="security.html">Security</a>
-            <a href="privacy.html">Privacy</a>
-            <a href="terms.html">Terms</a>
+            <p class="footer-title">More</p>
+            <a href="open-core.html">Open core</a>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
           </div>
         </div>
       </footer>

--- a/interoperability.html
+++ b/interoperability.html
@@ -1,0 +1,171 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua | Broadly Interoperable</title>
+    <meta
+      name="description"
+      content="How Honua is broadly interoperable through OGC standards, Esri compatibility, file formats, databases, gRPC, and MCP."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell minimal-shell">
+      <header class="topbar minimal-topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Modern GIS platform</span>
+          </div>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+        <nav class="nav-groups minimal-nav" aria-label="Primary">
+          <a class="nav-utility active" href="cloud-native.html">Platform</a>
+          <a class="nav-utility" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="mailto:info@honua.io">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Platform</p>
+          <h1>Broadly interoperable.</h1>
+          <p class="page-intro">
+            Honua connects existing GIS clients, common files and databases, standards-based services,
+            and modern protocol surfaces for new applications and AI agents.
+          </p>
+          <nav class="platform-nav" aria-label="Platform pages">
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+            <a class="active" href="interoperability.html">Interoperability</a>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </nav>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Standards surface</p>
+            <h2>Existing clients and new systems use the same deployment.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <colgroup>
+                <col class="surface-column" />
+                <col />
+                <col />
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>Surface</th>
+                  <th>How Honua supports it</th>
+                  <th>What it unlocks</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Surface">OGC and classic services</td>
+                  <td data-label="How Honua supports it">OGC API Features, Tiles, Maps; WFS, WMS, WMTS, and WCS.</td>
+                  <td data-label="What it unlocks">ArcGIS Pro, QGIS, web maps, partner systems, and standards-based clients.</td>
+                </tr>
+                <tr>
+                  <td data-label="Surface">Esri compatibility</td>
+                  <td data-label="How Honua supports it">GeoServices REST compatibility for ArcGIS-facing workloads.</td>
+                  <td data-label="What it unlocks">ArcGIS Pro, ArcGIS Online, Enterprise, JS API, and systems already built around Esri service URLs.</td>
+                </tr>
+                <tr>
+                  <td data-label="Surface">Files and object data</td>
+                  <td data-label="How Honua supports it">GeoJSON, GeoPackage, Shapefile, FlatGeobuf, GeoTIFF, COG, STAC, MVT, CSV with geometry, and GeoParquet.</td>
+                  <td data-label="What it unlocks">Data exchange, field workflows, archives, tiles, rasters, and analytics pipelines.</td>
+                </tr>
+                <tr>
+                  <td data-label="Surface">Databases</td>
+                  <td data-label="How Honua supports it">PostGIS/PostgreSQL-first workflows, cloud PostgreSQL variants, and SQLite/GeoPackage paths.</td>
+                  <td data-label="What it unlocks">Use existing spatial data stores without forcing a full data migration first.</td>
+                </tr>
+                <tr>
+                  <td data-label="Surface">Modern protocols</td>
+                  <td data-label="How Honua supports it">gRPC/Protobuf for typed high-throughput APIs and MCP for agent-readable spatial operations.</td>
+                  <td data-label="What it unlocks">New apps, SDKs, automation, and AI workflows without scraping maps or guessing schemas.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Conformance</p>
+            <h2>Compatibility backed by standards tests.</h2>
+            <p class="section-copy">
+              The standards page keeps the OGC API and classic OGC compliance work, protocol matrix, and
+              client compatibility notes together so teams can review the interoperability surface directly.
+            </p>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card">
+              <p class="card-kicker">OGC API Features</p>
+              <h3>137 / 137 tests passing</h3>
+              <p>Feature access conformance shown on the standards page.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Classic OGC</p>
+              <h3>WFS, WMS, WMTS, WCS</h3>
+              <p>Classic OGC service behavior is covered by compatibility and compliance testing.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">Innovation path</p>
+              <h3>gRPC and MCP</h3>
+              <p>New protocol work is published separately from the compatibility layer.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>Plan an incremental migration.</h2>
+          <p>Interoperability keeps existing clients connected while new work moves to modern APIs and workflows.</p>
+          <div class="action-row">
+            <a class="button button-primary" href="migration.html">Migration path</a>
+            <a class="button button-secondary" href="mailto:info@honua.io">Contact</a>
+            <a class="button button-ghost" href="index.html">Home</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer minimal-footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <a href="index.html">Home</a>
+            <a href="mailto:info@honua.io">Contact</a>
+          </div>
+          <div>
+            <p class="footer-title">Platform</p>
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+          </div>
+          <div>
+            <p class="footer-title">More</p>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </div>
+          <div>
+            <p class="footer-title">Contact</p>
+            <a href="mailto:info@honua.io">Email</a>
+            <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/migration.html
+++ b/migration.html
@@ -1,0 +1,166 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua | Easy to Adopt</title>
+    <meta
+      name="description"
+      content="How Honua is easy to adopt: Honua supports ArcGIS and GeoServer service import, standards ingestion, database and file migration, SDK converters, app converters, and parity checks."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell minimal-shell">
+      <header class="topbar minimal-topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Modern GIS platform</span>
+          </div>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+        <nav class="nav-groups minimal-nav" aria-label="Primary">
+          <a class="nav-utility active" href="cloud-native.html">Platform</a>
+          <a class="nav-utility" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="mailto:info@honua.io">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Platform</p>
+          <h1>Easy to adopt.</h1>
+          <p class="page-intro">
+            Honua is built for incremental movement:
+            import existing services, validate parity, keep clients connected, and move new work to modern APIs.
+          </p>
+          <nav class="platform-nav" aria-label="Platform pages">
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a class="active" href="migration.html">Adoption</a>
+          </nav>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Migration path</p>
+            <h2>Lower switching cost comes from compatibility plus automation.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Path</th>
+                  <th>How Honua supports it</th>
+                  <th>Adoption value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Path">ArcGIS service import</td>
+                  <td data-label="How Honua supports it">Import FeatureServer, MapServer, metadata, schemas, styles, permissions, and service references as part of the migration scope.</td>
+                  <td data-label="Adoption value">Existing ArcGIS-facing clients can be validated against Honua before cutover.</td>
+                </tr>
+                <tr>
+                  <td data-label="Path">GeoServer service import</td>
+                  <td data-label="How Honua supports it">Import WFS, WMS, WMTS, WCS, layers, styles, CRS, metadata, and service endpoints as part of the migration scope.</td>
+                  <td data-label="Adoption value">GeoServer-facing clients keep using familiar standards while the backend changes.</td>
+                </tr>
+                <tr>
+                  <td data-label="Path">Standards and data ingestion</td>
+                  <td data-label="How Honua supports it">OGC services, GeoServices REST, files, databases, and object storage paths support staged movement.</td>
+                  <td data-label="Adoption value">Teams can move service by service and dataset by dataset.</td>
+                </tr>
+                <tr>
+                  <td data-label="Path">SDK and app converters</td>
+                  <td data-label="How Honua supports it">Migration helpers can identify repeatable ArcGIS JS, SDK, layer config, style, form, and service-reference patterns.</td>
+                  <td data-label="Adoption value">Mechanical app migration work gets automated, while hard judgement calls stay visible.</td>
+                </tr>
+                <tr>
+                  <td data-label="Path">Parity checks</td>
+                  <td data-label="How Honua supports it">Compare features, tiles, rendered maps, response shapes, and workflow behavior side by side.</td>
+                  <td data-label="Adoption value">Teams can prove equivalent behavior before users are moved.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">Migration model</p>
+            <h2>Run old and new together.</h2>
+            <p class="section-copy">
+              The intended adoption path is side-by-side: keep legacy clients on standards and compatibility
+              surfaces, move new work to SDKs, gRPC, and agents, then cut over at the pace the organization can support.
+            </p>
+          </div>
+          <div class="card-grid card-grid-three">
+            <article class="card">
+              <p class="card-kicker">1. Import</p>
+              <h3>Bring existing services forward.</h3>
+              <p>Start with ArcGIS, GeoServer, files, and database-backed services already in production.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">2. Validate</p>
+              <h3>Check parity before rollout.</h3>
+              <p>Compare outputs and fix differences before changing user traffic.</p>
+            </article>
+            <article class="card">
+              <p class="card-kicker">3. Expand</p>
+              <h3>Move new work to modern interfaces.</h3>
+              <p>Use SDKs, gRPC, MCP, GitOps, and AI workflows once the foundation is in place.</p>
+            </article>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>Review the migration path.</h2>
+          <p>Start with service import, parity checks, and a side-by-side rollout plan.</p>
+          <div class="action-row">
+            <a class="button button-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a class="button button-secondary" href="interoperability.html">Interoperability</a>
+            <a class="button button-ghost" href="index.html">Home</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer minimal-footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <a href="index.html">Home</a>
+            <a href="mailto:info@honua.io">Contact</a>
+          </div>
+          <div>
+            <p class="footer-title">Platform</p>
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+          </div>
+          <div>
+            <p class="footer-title">More</p>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+          </div>
+          <div>
+            <p class="footer-title">Contact</p>
+            <a href="mailto:info@honua.io">Email</a>
+            <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/open-core.html
+++ b/open-core.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua | Open-Core Geoplatform</title>
+    <meta
+      name="description"
+      content="How Honua works as an open-core geoplatform: public server, SDK, protocol, portal, admin, operations, and deployment repositories with clear license boundaries."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell minimal-shell">
+      <header class="topbar minimal-topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Modern GIS platform</span>
+          </div>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+        <nav class="nav-groups minimal-nav" aria-label="Primary">
+          <a class="nav-utility active" href="cloud-native.html">Platform</a>
+          <a class="nav-utility" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="mailto:info@honua.io">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Platform</p>
+          <h1>Open-core geoplatform.</h1>
+          <p class="page-intro">
+            Honua's platform surface is visible across repositories: the runtime, SDKs, protocol specs,
+            deployment modules, portal, admin, operations tools, and benchmarks. The license boundary is explicit.
+          </p>
+          <nav class="platform-nav" aria-label="Platform pages">
+            <a href="cloud-native.html">Cloud-native</a>
+            <a class="active" href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </nav>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Repository map</p>
+            <h2>The platform is more than a server binary.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Area</th>
+                  <th>How Honua supports it</th>
+                  <th>Reference</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Area">Core runtime</td>
+                  <td data-label="How Honua supports it">The geospatial server is inspectable and self-hostable, with the commercial boundary at the core runtime.</td>
+                  <td data-label="Reference"><a class="text-link" href="https://github.com/honua-io/honua-server" target="_blank" rel="noopener noreferrer">honua-server</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Area">SDKs and protocols</td>
+                  <td data-label="How Honua supports it">Client SDKs and public protocol specs give developers a path that is not tied to a single UI.</td>
+                  <td data-label="Reference"><a class="text-link" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">SDK repos</a>, <a class="text-link" href="https://github.com/honua-io/geospatial-grpc" target="_blank" rel="noopener noreferrer">geospatial-grpc</a>, and <a class="text-link" href="https://github.com/honua-io/geospatial-mcp" target="_blank" rel="noopener noreferrer">geospatial-mcp</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Area">Portal and admin</td>
+                  <td data-label="How Honua supports it">The human-facing platform surface is separate from the runtime and can evolve without hiding the core infrastructure.</td>
+                  <td data-label="Reference"><a class="text-link" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">Honua organization</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Area">Deployment and operations</td>
+                  <td data-label="How Honua supports it">Terraform, Helm, GitOps, observability, and AI DevOps tooling sit around the core platform.</td>
+                  <td data-label="Reference"><a class="text-link" href="operations.html">Operations</a>.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="section section-contrast">
+          <div class="section-heading">
+            <p class="eyebrow">License boundary</p>
+            <h2>Source-available core, open surrounding ecosystem, commercial pro features.</h2>
+            <p class="section-copy">
+              The core runtime is source-available under ELv2. SDKs, tools, protocol work, and ecosystem
+              repositories use Apache-2.0 where applicable. Enterprise and pro capabilities are commercial.
+            </p>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Layer</th>
+                  <th>License posture</th>
+                  <th>Why it matters</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Layer">Core server</td>
+                  <td data-label="License posture">ELv2 source-available runtime.</td>
+                  <td data-label="Why it matters">Teams can inspect and self-host the core while Honua keeps a sustainable commercial boundary.</td>
+                </tr>
+                <tr>
+                  <td data-label="Layer">SDKs, tools, specs</td>
+                  <td data-label="License posture">Apache-2.0 where published as open ecosystem components.</td>
+                  <td data-label="Why it matters">Developers can build clients, integrations, and automation without a closed client stack.</td>
+                </tr>
+                <tr>
+                  <td data-label="Layer">Enterprise and pro features</td>
+                  <td data-label="License posture">Commercial.</td>
+                  <td data-label="Why it matters">Paid features align to production needs: governance, support, enterprise identity, managed delivery, and scale controls.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="platform-note">
+            ELv2 is source-available, not OSI open source. Honua keeps that license boundary explicit.
+          </p>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>Review the public surface.</h2>
+          <p>The repo map and license boundary show how the open-core model works.</p>
+          <div class="action-row">
+            <a class="button button-primary" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">Browse GitHub</a>
+            <a class="button button-secondary" href="mailto:info@honua.io">Contact</a>
+            <a class="button button-ghost" href="index.html">Home</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer minimal-footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <a href="index.html">Home</a>
+            <a href="mailto:info@honua.io">Contact</a>
+          </div>
+          <div>
+            <p class="footer-title">Platform</p>
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="operations.html">Operations</a>
+            <a href="interoperability.html">Interoperability</a>
+          </div>
+          <div>
+            <p class="footer-title">More</p>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </div>
+          <div>
+            <p class="footer-title">Contact</p>
+            <a href="mailto:info@honua.io">Email</a>
+            <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/operations.html
+++ b/operations.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua | Easy to Operate</title>
+    <meta
+      name="description"
+      content="How Honua is easy to operate: containers, Terraform, GitOps, OpenTelemetry, cloud marketplaces, OIDC, autoscaling, and AI DevOps."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell minimal-shell">
+      <header class="topbar minimal-topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Modern GIS platform</span>
+          </div>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+        <nav class="nav-groups minimal-nav" aria-label="Primary">
+          <a class="nav-utility active" href="cloud-native.html">Platform</a>
+          <a class="nav-utility" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="mailto:info@honua.io">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Platform</p>
+          <h1>Easy to operate.</h1>
+          <p class="page-intro">
+            Honua fits the tools platform teams already use, so GIS can be deployed, observed, scaled,
+            and updated like other production services.
+          </p>
+          <nav class="platform-nav" aria-label="Platform pages">
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a class="active" href="operations.html">Operations</a>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </nav>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Operator view</p>
+            <h2>Deployment, change control, telemetry, and diagnostics.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Area</th>
+                  <th>How Honua supports it</th>
+                  <th>Operator value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Area">Containers</td>
+                  <td data-label="How Honua supports it">Lightweight container deployment with health checks, environment-based config, and standard ingress patterns.</td>
+                  <td data-label="Operator value">Run GIS on existing container platforms instead of a separate appliance model.</td>
+                </tr>
+                <tr>
+                  <td data-label="Area">Terraform and marketplaces</td>
+                  <td data-label="How Honua supports it">Infrastructure as code modules and marketplace delivery paths for cloud buyers.</td>
+                  <td data-label="Operator value">Repeatable deployment and simpler procurement.</td>
+                </tr>
+                <tr>
+                  <td data-label="Area">GitOps</td>
+                  <td data-label="How Honua supports it">Service configuration, rollout review, and rollback can flow through pull requests.</td>
+                  <td data-label="Operator value">Auditable changes instead of console-only administration.</td>
+                </tr>
+                <tr>
+                  <td data-label="Area">OpenTelemetry</td>
+                  <td data-label="How Honua supports it">Traces, metrics, and logs can connect runtime behavior to the rest of the stack.</td>
+                  <td data-label="Operator value">Faster incident response and concrete performance tuning.</td>
+                </tr>
+                <tr>
+                  <td data-label="Area">AI DevOps</td>
+                  <td data-label="How Honua supports it">Agent-readable operations surfaces for deploy status, logs, traces, config checks, and runbook actions.</td>
+                  <td data-label="Operator value">Lower routine burden while keeping humans in the review loop.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>See the operating model.</h2>
+          <p>Operations and cloud-native architecture are connected; this page focuses on the teams who run the platform.</p>
+          <div class="action-row">
+            <a class="button button-primary" href="mailto:info@honua.io">Talk to us</a>
+            <a class="button button-secondary" href="cloud-native.html">Cloud-native</a>
+            <a class="button button-ghost" href="index.html">Home</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer minimal-footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <a href="index.html">Home</a>
+            <a href="mailto:info@honua.io">Contact</a>
+          </div>
+          <div>
+            <p class="footer-title">Platform</p>
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="interoperability.html">Interoperability</a>
+          </div>
+          <div>
+            <p class="footer-title">More</p>
+            <a href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </div>
+          <div>
+            <p class="footer-title">Contact</p>
+            <a href="mailto:info@honua.io">Email</a>
+            <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/performance.html
+++ b/performance.html
@@ -1,0 +1,138 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua | High Performance</title>
+    <meta
+      name="description"
+      content="Honua uses an AOT runtime, lightweight containers, gRPC, GeoBench, and operational telemetry for high-performance geospatial workloads."
+    />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="assets/analytics.js"></script>
+  </head>
+  <body>
+    <div class="site-shell minimal-shell">
+      <header class="topbar minimal-topbar">
+        <a class="brand" href="index.html" aria-label="Honua home">
+          <img src="assets/honua-logo.png" alt="Honua logo" />
+          <div>
+            <span class="brand-name">Honua</span>
+            <span class="brand-tag">Modern GIS platform</span>
+          </div>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+        <nav class="nav-groups minimal-nav" aria-label="Primary">
+          <a class="nav-utility active" href="cloud-native.html">Platform</a>
+          <a class="nav-utility" href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a class="button button-nav" href="mailto:info@honua.io">Contact</a>
+        </nav>
+      </header>
+
+      <main>
+        <section class="page-hero">
+          <p class="eyebrow">Platform</p>
+          <h1>High performance.</h1>
+          <p class="page-intro">
+            Honua combines AOT compilation, lightweight containers, gRPC, OpenTelemetry, and GeoBench
+            to keep spatial workloads responsive and measurable.
+          </p>
+          <nav class="platform-nav" aria-label="Platform pages">
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+            <a href="interoperability.html">Interoperability</a>
+            <a class="active" href="performance.html">Performance</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </nav>
+        </section>
+
+        <section class="section">
+          <div class="section-heading">
+            <p class="eyebrow">Performance basis</p>
+            <h2>Fast needs numbers and reproducible tests.</h2>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Capability</th>
+                  <th>How Honua supports it</th>
+                  <th>Reference</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td data-label="Capability">Low runtime overhead</td>
+                  <td data-label="How Honua supports it">AOT compilation and a lean process model reduce startup and memory pressure.</td>
+                  <td data-label="Reference"><a class="text-link" href="cloud-native.html">Cloud-native runtime</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Capability">Efficient deployment</td>
+                  <td data-label="How Honua supports it">Lightweight containers support smaller resource requests, faster rollout, and better scale behavior.</td>
+                  <td data-label="Reference"><a class="text-link" href="cloud-native.html">Cloud-native</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Capability">High-throughput application path</td>
+                  <td data-label="How Honua supports it">gRPC and Protobuf provide typed binary APIs for new apps, services, and agents.</td>
+                  <td data-label="Reference"><a class="text-link" href="https://github.com/honua-io/geospatial-grpc" target="_blank" rel="noopener noreferrer">geospatial-grpc</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Capability">Benchmarkable performance</td>
+                  <td data-label="How Honua supports it">GeoBench provides datasets, commands, hardware notes, comparisons, and raw results.</td>
+                  <td data-label="Reference"><a class="text-link" href="https://github.com/honua-io/geobench" target="_blank" rel="noopener noreferrer">geobench</a>.</td>
+                </tr>
+                <tr>
+                  <td data-label="Capability">Observable tuning</td>
+                  <td data-label="How Honua supports it">OpenTelemetry gives operators request-level visibility into slow queries, cache behavior, and database time.</td>
+                  <td data-label="Reference"><a class="text-link" href="operations.html">Operations</a>.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="cta-band">
+          <p class="eyebrow">Next</p>
+          <h2>Run the benchmarks.</h2>
+          <p>GeoBench keeps benchmark commands, raw results, and environment notes in one place.</p>
+          <div class="action-row">
+            <a class="button button-primary" href="https://github.com/honua-io/geobench" target="_blank" rel="noopener noreferrer">GeoBench</a>
+            <a class="button button-secondary" href="cloud-native.html">Cloud-native</a>
+            <a class="button button-ghost" href="index.html">Home</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer minimal-footer">
+        <div class="footer-grid">
+          <div>
+            <p class="footer-title">Honua</p>
+            <a href="index.html">Home</a>
+            <a href="mailto:info@honua.io">Contact</a>
+          </div>
+          <div>
+            <p class="footer-title">Platform</p>
+            <a href="cloud-native.html">Cloud-native</a>
+            <a href="open-core.html">Open core</a>
+            <a href="operations.html">Operations</a>
+          </div>
+          <div>
+            <p class="footer-title">More</p>
+            <a href="interoperability.html">Interoperability</a>
+            <a href="ai-gis.html">AI-ready</a>
+            <a href="migration.html">Adoption</a>
+          </div>
+          <div>
+            <p class="footer-title">Contact</p>
+            <a href="mailto:info@honua.io">Email</a>
+            <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub</a>
+          </div>
+        </div>
+      </footer>
+    </div>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -707,6 +707,10 @@ table {
   border-collapse: collapse;
 }
 
+.surface-column {
+  width: 28%;
+}
+
 th,
 td {
   padding: 16px 18px;
@@ -871,6 +875,102 @@ pre {
 
 .cta-band p {
   max-width: 58ch;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+/* Minimal platform site */
+.minimal-shell {
+  --max-width: 980px;
+}
+
+.minimal-topbar {
+  align-items: center;
+}
+
+.minimal-nav {
+  gap: 10px;
+}
+
+.minimal-home h1 {
+  max-width: 16ch;
+}
+
+.home-statement {
+  max-width: 78ch;
+  margin: 26px 0 0;
+  color: var(--muted-strong);
+  font-size: clamp(1.2rem, 2.4vw, 1.58rem);
+  line-height: 1.65;
+}
+
+.home-statement a {
+  color: var(--accent-strong);
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: rgba(113, 241, 210, 0.34);
+  text-underline-offset: 0.18em;
+}
+
+.home-statement a:hover {
+  color: var(--ink);
+  text-decoration-color: currentColor;
+}
+
+.comparison-section h2,
+.platform-index h2 {
+  max-width: 28ch;
+}
+
+.platform-link-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.platform-link-grid a {
+  display: flex;
+  align-items: center;
+  min-height: 58px;
+  padding: 16px 18px;
+  border: 1px solid rgba(142, 190, 185, 0.14);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--muted-strong);
+  font-weight: 700;
+}
+
+.platform-link-grid a:hover {
+  color: var(--ink);
+  border-color: rgba(113, 241, 210, 0.28);
+  background: rgba(38, 216, 173, 0.08);
+}
+
+.platform-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.platform-nav a {
+  padding: 9px 12px;
+  border: 1px solid rgba(142, 190, 185, 0.14);
+  border-radius: 999px;
+  color: var(--muted-strong);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.platform-nav a:hover,
+.platform-nav a.active {
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.07);
+}
+
+.platform-note {
+  max-width: 68ch;
+  margin: 18px 0 0;
   color: var(--muted);
   line-height: 1.7;
 }


### PR DESCRIPTION
## Summary

Replaces the dense homepage with a minimal paragraph-led front page for the modern GIS platform positioning.

Adds seven focused platform pages for the linked concepts:

- Modern cloud-native
- Open-core geoplatform
- Easy to operate
- Broadly interoperable
- High performance
- AI-ready GIS
- Easy to adopt

The new launch flow is self-contained: homepage, the seven platform pages, GitHub, and `info@honua.io`. Legacy pages remain in the repository, but the new front-door journey no longer routes visitors into the old menu structure.

## Impact

This gives honua.io a simpler client-facing entry point with clearer business outcomes: lower operating and licensing cost, faster GIS delivery, better performance, and incremental adoption.

## Validation

- `bash scripts/build-dist.sh`
- Local new-flow link check for missing files, missing fragments, and links into legacy HTML pages
- Local preview smoke checks returned `200` for `/`, `/cloud-native.html`, and `/ai-gis.html`