### PR TITLE
Update homepage migration example + site-wide accuracy audit fixes

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -89,7 +89,7 @@ curl http://localhost:8080/admin/services \
 <pre><code>pip install honua-sdk
 
 python - &lt;&lt;'PY'
-from honua import HonuaClient
+from honua_sdk import HonuaClient
 client = HonuaClient(base_url="http://localhost:8080", token="$TOKEN")
 print(client.services.list())
 PY</code></pre>

--- a/index.html
+++ b/index.html
@@ -91,24 +91,25 @@
             <span class="title">~/honua-migration · zsh</span>
           </div>
           <div class="term-body">
-            <div class="line"><span class="c"># 1. Import services from the ArcGIS estate.</span></div>
-            <div class="line"><span class="p">$</span> honua import arcgis --dry-run \</div>
-            <div class="line">    --from gis.example.gov/arcgis/rest</div>
+            <div class="line"><span class="c"># 1. Scan an ArcGIS portal for hosted content.</span></div>
+            <div class="line"><span class="p">$</span> honua-migrate content scan \</div>
+            <div class="line">    --portal https://gis.example.gov/portal</div>
             <div class="line"><span class="ok">✓</span> scanned <span class="v">FeatureServer</span> · <span class="v">MapServer</span> · <span class="v">ImageServer</span></div>
-            <div class="line"><span class="ok">✓</span> schemas, styles, permissions captured</div>
-            <div class="line"><span class="info">ℹ</span> pilot-scoped run · <span class="c">parity report below</span></div>
+            <div class="line"><span class="ok">✓</span> webmaps, hosted layers, and portal items catalogued</div>
+            <div class="line"><span class="info">ℹ</span> dry run · <span class="c">use `content export` + `content import` to migrate</span></div>
             <div class="line">&nbsp;</div>
             <div class="line"><span class="c"># 2. Convert ArcGIS JS apps with the SDK codemod.</span></div>
-            <div class="line"><span class="p">$</span> honua convert js ./webmap-app/</div>
+            <div class="line"><span class="p">$</span> honua-migrate codemod ./webmap-app \</div>
+            <div class="line">    --target honua-compat --write --report parity.json</div>
             <div class="line"><span class="c">  analyzing source files...</span></div>
-            <div class="line"><span class="ok">✓</span> rewrote ArcGIS JS imports     <span class="c">→ @honua/sdk</span></div>
-            <div class="line"><span class="ok">✓</span> rewrote FeatureLayer constructors</div>
-            <div class="line"><span class="ok">✓</span> rewrote portal references</div>
-            <div class="line"><span class="ok">~</span> <span class="v">85–95%</span> automated · remainder flagged for review</div>
+            <div class="line"><span class="ok">✓</span> rewrote ArcGIS JS imports     <span class="c">→ @honua/sdk-esri-compat</span></div>
+            <div class="line"><span class="ok">✓</span> rewrote FeatureLayer / MapView / Query constructors</div>
+            <div class="line"><span class="ok">✓</span> rewrote reactiveUtils.watch accessors and event names</div>
+            <div class="line"><span class="ok">~</span> remaining call sites annotated <span class="v">TODO(honua-migrate)</span></div>
             <div class="line">&nbsp;</div>
-            <div class="line"><span class="c"># 3. Validate parity, then ship side-by-side.</span></div>
-            <div class="line"><span class="p">$</span> honua parity --report</div>
-            <div class="line"><span class="c">  diffs features · tiles · rendered maps</span></div>
+            <div class="line"><span class="c"># 3. Validate parity gates, then ship side-by-side.</span></div>
+            <div class="line"><span class="p">$</span> honua-migrate fixtures --report parity.json</div>
+            <div class="line"><span class="c">  no-manual-todos · no-unhandled-modules · no-blocking-flags</span></div>
             <div class="line"><span class="p">$</span> <span class="v">_</span></div>
           </div>
         </div>

--- a/interoperability.html
+++ b/interoperability.html
@@ -62,18 +62,18 @@
           <div class="head">URL &amp; SDK mapping · drop-in</div>
           <div class="grp">
             <div class="gh">Service endpoints</div>
-            <div class="row"><span class="from">/arcgis/rest/services/Parcels/FeatureServer/0</span><span class="arrow">→</span><span class="to">/services/features/Parcels/v1/0</span></div>
-            <div class="row"><span class="from">/arcgis/rest/services/Zoning/MapServer</span><span class="arrow">→</span><span class="to">/services/map/Zoning/v1</span></div>
-            <div class="row"><span class="from">/arcgis/rest/services/NAIP/ImageServer</span><span class="arrow">→</span><span class="to">/services/image/NAIP/v1</span></div>
-            <div class="row"><span class="from">/arcgis/rest/services/Route/GPServer</span><span class="arrow">→</span><span class="to">/services/gp/Route/v1</span></div>
+            <div class="row"><span class="from">/arcgis/rest/services/Parcels/FeatureServer/0</span><span class="arrow">→</span><span class="to">/rest/services/Parcels/FeatureServer/0</span></div>
+            <div class="row"><span class="from">/arcgis/rest/services/Zoning/MapServer</span><span class="arrow">→</span><span class="to">/rest/services/Zoning/MapServer</span></div>
+            <div class="row"><span class="from">/arcgis/rest/services/NAIP/ImageServer</span><span class="arrow">→</span><span class="to">/rest/services/NAIP/ImageServer</span></div>
+            <div class="row"><span class="from">/arcgis/rest/services/Route/GPServer</span><span class="arrow">→</span><span class="to">/rest/services/Route/GPServer</span></div>
             <div class="row"><span class="from">/geoserver/wfs · wms · wmts · wcs</span><span class="arrow">→</span><span class="to">/ogc/wfs · wms · wmts · wcs</span></div>
           </div>
           <div class="grp">
             <div class="gh">SDK · parity by design</div>
-            <div class="row"><span class="from">@arcgis/core/Map</span><span class="arrow">→</span><span class="to">@honua/sdk → Map</span></div>
-            <div class="row"><span class="from">@arcgis/core/views/MapView</span><span class="arrow">→</span><span class="to">@honua/sdk → MapView</span></div>
-            <div class="row"><span class="from">@arcgis/core/layers/FeatureLayer</span><span class="arrow">→</span><span class="to">@honua/sdk → FeatureLayer</span></div>
-            <div class="row"><span class="from">@arcgis/core/Graphic · Symbol · Renderer</span><span class="arrow">→</span><span class="to">@honua/sdk → matching surface</span></div>
+            <div class="row"><span class="from">@arcgis/core/Map</span><span class="arrow">→</span><span class="to">@honua/sdk-esri-compat → MapCompat</span></div>
+            <div class="row"><span class="from">@arcgis/core/views/MapView</span><span class="arrow">→</span><span class="to">@honua/sdk-esri-compat → MapViewCompat</span></div>
+            <div class="row"><span class="from">@arcgis/core/layers/FeatureLayer</span><span class="arrow">→</span><span class="to">@honua/sdk-esri-compat → FeatureLayerCompat</span></div>
+            <div class="row"><span class="from">@arcgis/core/Graphic · Symbol · Renderer</span><span class="arrow">→</span><span class="to">@honua/sdk-esri-compat → matching <em>Compat</em> surface</span></div>
           </div>
         </div>
       </section>
@@ -118,13 +118,13 @@
           <div class="bed-proof-card">
             <div class="ph"><span class="gh">SDK · parity by design</span><span class="live">EVIDENCED</span></div>
             <span class="gt">Compatibility-by-design surface.</span>
-            <p class="gp">Each Honua SDK is shaped to match its Esri counterpart 1:1 — not a fork. Conversion happens through <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua convert</code> codemods with rewrite categories and review flagging documented per language.</p>
+            <p class="gp">Each Honua SDK is shaped to match its Esri counterpart 1:1 — not a fork. Conversion happens through the <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua-migrate codemod</code> on the JavaScript SDK today; other languages ship their parity surface and gain codemod coverage on the roadmap.</p>
             <div class="rows">
-              <div class="pr"><span class="nm">JavaScript SDK</span><span class="ct"><span class="ok">✓</span>parity surface</span></div>
+              <div class="pr"><span class="nm">JavaScript SDK</span><span class="ct"><span class="ok">✓</span>deterministic 2D parity</span></div>
               <div class="pr"><span class="nm">Python SDK</span><span class="ct"><span class="ok">✓</span>parity surface</span></div>
               <div class="pr"><span class="nm">.NET SDK</span><span class="ct"><span class="ok">✓</span>parity surface</span></div>
-              <div class="pr"><span class="nm">iOS + Android SDKs</span><span class="ct"><span class="ok">✓</span>parity surface</span></div>
-              <div class="pr"><span class="nm">honua convert · codemod</span><span class="ct"><span class="ok">✓</span>per-SDK</span></div>
+              <div class="pr"><span class="nm">Mobile · .NET MAUI</span><span class="ct">roadmap</span></div>
+              <div class="pr"><span class="nm">honua-migrate codemod · JS</span><span class="ct"><span class="ok">✓</span>shipped</span></div>
             </div>
             <div class="foot"><a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">↗ sdk-js · sdk-python · sdk-dotnet · honua-mobile</a></div>
           </div>

--- a/migration.html
+++ b/migration.html
@@ -62,28 +62,29 @@
             <span class="dot" style="background: #ff5f57"></span>
             <span class="dot" style="background: #febc2e"></span>
             <span class="dot" style="background: #28c840"></span>
-            <span class="title">honua parity-check · example output</span>
+            <span class="title">honua-migrate codemod · example output</span>
           </div>
           <div class="term-body">
-            <div class="line"><span class="p">→</span> honua parity --against arcgis://gis.example.gov</div>
-            <div class="line"><span class="c">  diffs features · tiles · rendered maps...</span></div>
-            <div class="line"><span class="ok">✓</span> FeatureServer/Parcels        <span class="v">scoped</span></div>
-            <div class="line"><span class="ok">✓</span> MapServer/Zoning             <span class="v">scoped</span></div>
-            <div class="line"><span class="ok">✓</span> ImageServer/NAIP_2024        <span class="v">scoped</span></div>
-            <div class="line"><span class="ok">✓</span> GPServer/RouteSolver         <span class="v">scoped</span></div>
+            <div class="line"><span class="p">→</span> honua-migrate codemod ./webmap-app \</div>
+            <div class="line">    --target honua-compat --write --report parity.json</div>
+            <div class="line"><span class="c">  analyzing source files...</span></div>
+            <div class="line"><span class="ok">✓</span> FeatureLayer / MapView / Map  <span class="v">rewritten</span></div>
+            <div class="line"><span class="ok">✓</span> Query options                 <span class="v">deep-transformed</span></div>
+            <div class="line"><span class="ok">✓</span> reactiveUtils.watch accessors <span class="v">rewritten</span></div>
+            <div class="line"><span class="ok">✓</span> event names remapped          <span class="v">layer-view-created · …</span></div>
             <div class="line">&nbsp;</div>
-            <div class="line"><span class="info">ℹ</span> parity is partial · per-service gaps tracked in the parity matrix</div>
-            <div class="line"><span class="ok">→</span> diff dropped to ./parity-report.json</div>
-            <div class="line"><span class="c"># example output · pilot-scoped run; real numbers come from your run</span></div>
+            <div class="line"><span class="info">ℹ</span> parity is partial · gaps in docs/migration-punch-list.md</div>
+            <div class="line"><span class="ok">→</span> report written to ./parity.json</div>
+            <div class="line"><span class="c"># real binary in honua-sdk-js; numbers come from your run</span></div>
           </div>
         </div>
       </section>
 
       <section class="bed-pillar-detail">
         <div class="section-head">
-          <span class="eyebrow">// sdk converters · 4 languages</span>
+          <span class="eyebrow">// sdk converters · JS today · others on roadmap</span>
           <h2>One converter <span class="teal">per SDK.</span> Same playbook.</h2>
-          <p class="sub">JavaScript, .NET, Python, and mobile each ship a <span class="mono" style="color: var(--bed-text);">honua convert</span> command tuned to that ecosystem — scanner, codemod, rewrites, and a flagged-for-review list. Your team picks the one that matches the app they're moving.</p>
+          <p class="sub">JavaScript ships a real <span class="mono" style="color: var(--bed-text);">honua-migrate codemod</span> today — AST scanner, constructor rewrites, event-name + Query option transforms, and a flagged-for-review list with a parity report. The .NET, Python, and MAUI converters follow the same playbook and are on the roadmap; their parity surfaces ship today.</p>
         </div>
         <div class="bed-conv-grid">
           <div class="bed-conv-card">
@@ -91,15 +92,15 @@
               <span class="badge">JS</span>
               <div>
                 <div class="name">JavaScript SDK</div>
-                <div class="sub">@honua/sdk · scanner + codemod</div>
+                <div class="sub">@honua/sdk-esri-compat · scanner + codemod</div>
               </div>
               <span class="stat prod">production tooling</span>
             </div>
-            <div class="cmd"><span class="p">$</span>honua convert js <span class="a">./webmap-app/</span></div>
+            <div class="cmd"><span class="p">$</span>honua-migrate codemod <span class="a">./webmap-app --target honua-compat --write</span></div>
             <div class="flow">
               <span class="from">@arcgis/core</span>
               <span class="arr">→</span>
-              <span class="to">@honua/sdk</span>
+              <span class="to">@honua/sdk-esri-compat</span>
             </div>
             <div class="block">
               <span class="lbl">// what the converter rewrites</span>
@@ -120,9 +121,9 @@
                 <div class="name">.NET SDK</div>
                 <div class="sub">Honua .NET · Roslyn codemod + adapters</div>
               </div>
-              <span class="stat prod">production tooling</span>
+              <span class="stat scaff">roadmap</span>
             </div>
-            <div class="cmd"><span class="p">$</span>honua convert dotnet <span class="a">./MyApp.csproj</span></div>
+            <div class="cmd"><span class="p">$</span>honua-migrate dotnet <span class="a">./MyApp.csproj</span> <span class="c">// roadmap</span></div>
             <div class="flow">
               <span class="from">ArcGIS Runtime .NET</span>
               <span class="arr">→</span>
@@ -147,9 +148,9 @@
                 <div class="name">Python SDK</div>
                 <div class="sub">honua-sdk-python · scanner + rewrites</div>
               </div>
-              <span class="stat scaff">prod · ArcPy in flight</span>
+              <span class="stat scaff">roadmap</span>
             </div>
-            <div class="cmd"><span class="p">$</span>honua convert python <span class="a">./notebooks/ ./scripts/</span></div>
+            <div class="cmd"><span class="p">$</span>honua-migrate python <span class="a">./notebooks/ ./scripts/</span> <span class="c">// roadmap</span></div>
             <div class="flow">
               <span class="from">arcgis (Esri Python) + arcpy</span>
               <span class="arr">→</span>
@@ -174,9 +175,9 @@
                 <div class="name">Mobile SDK · .NET MAUI</div>
                 <div class="sub">honua-mobile · MAUI codemod + offline sync</div>
               </div>
-              <span class="stat scaff">foundation</span>
+              <span class="stat scaff">roadmap</span>
             </div>
-            <div class="cmd"><span class="p">$</span>honua convert maui <span class="a">./MobileApp.sln</span></div>
+            <div class="cmd"><span class="p">$</span>honua-migrate maui <span class="a">./MobileApp.sln</span> <span class="c">// roadmap</span></div>
             <div class="flow">
               <span class="from">ArcGIS Maps SDK · MAUI / Xamarin</span>
               <span class="arr">→</span>
@@ -200,11 +201,11 @@
         <div class="section-head">
           <span class="eyebrow">// js converter · example output</span>
           <h2>Here's what one of those rewrites looks like.</h2>
-          <p class="sub">A representative <span class="mono" style="color: var(--bed-text);">honua convert js</span> diff. The shape of the ArcGIS surface is preserved; the runtime, transport, and infrastructure underneath are Honua's. The .NET, Python, and MAUI converters apply the same pattern to their ecosystems.</p>
+          <p class="sub">A representative <span class="mono" style="color: var(--bed-text);">honua-migrate codemod</span> diff. The shape of the ArcGIS surface is preserved through the <em>Compat</em> classes; the runtime, transport, and infrastructure underneath are Honua's. The .NET, Python, and MAUI converters will apply the same pattern to their ecosystems on the roadmap.</p>
         </div>
         <div class="bed-diff">
           <div class="bed-diff-head">
-            <span class="label">honua convert app · diff</span>
+            <span class="label">honua-migrate codemod · diff</span>
             <span class="path">webmap-app/src/MapView.jsx</span>
           </div>
           <div class="bed-diff-body">
@@ -223,15 +224,15 @@
               <div class="bed-diff-line">map.add(parcels);</div>
             </div>
             <div class="bed-diff-col after">
-              <div class="colhead"><span class="pill">AFTER · AUTOMATED</span><span>@honua/sdk · v1</span></div>
-              <div class="bed-diff-line"><span class="com">// imports · constructors · portal refs rewritten</span></div>
-              <div class="bed-diff-line"><span class="key">import</span> { <span class="ren">Map</span>, <span class="ren">MapView</span>, <span class="ren">FeatureLayer</span> } from <span class="str">"@honua/sdk"</span>;</div>
+              <div class="colhead"><span class="pill">AFTER · AUTOMATED</span><span>@honua/sdk-esri-compat</span></div>
+              <div class="bed-diff-line"><span class="com">// imports + constructors rewritten to Compat surface</span></div>
+              <div class="bed-diff-line"><span class="key">import</span> { <span class="ren">MapCompat</span>, <span class="ren">MapViewCompat</span>, <span class="ren">FeatureLayerCompat</span> } from <span class="str">"@honua/sdk-esri-compat"</span>;</div>
               <div class="bed-diff-line">&nbsp;</div>
               <div class="bed-diff-line">&nbsp;</div>
               <div class="bed-diff-line">&nbsp;</div>
-              <div class="bed-diff-line"><span class="key">const</span> map = <span class="key">new</span> <span class="ren">Map</span>({ basemap: <span class="str">"streets-navigation-vector"</span> });</div>
-              <div class="bed-diff-line"><span class="key">const</span> view = <span class="key">new</span> <span class="ren">MapView</span>({ container: <span class="str">"viewDiv"</span>, map });</div>
-              <div class="bed-diff-line"><span class="key">const</span> parcels = <span class="key">new</span> <span class="ren">FeatureLayer</span>({</div>
+              <div class="bed-diff-line"><span class="key">const</span> map = <span class="key">new</span> <span class="ren">MapCompat</span>({ basemap: <span class="str">"streets-navigation-vector"</span> });</div>
+              <div class="bed-diff-line"><span class="key">const</span> view = <span class="key">new</span> <span class="ren">MapViewCompat</span>({ container: <span class="str">"viewDiv"</span>, map });</div>
+              <div class="bed-diff-line"><span class="key">const</span> parcels = <span class="key">new</span> <span class="ren">FeatureLayerCompat</span>({</div>
               <div class="bed-diff-line">  url: <span class="str">"https://gis.acme.gov/.../Parcels/FeatureServer/0"</span>,</div>
               <div class="bed-diff-line">});</div>
               <div class="bed-diff-line">map.add(parcels);</div>
@@ -256,8 +257,8 @@
               </tr>
               <tr>
                 <td class="area">App conversion (SDK parity)</td>
-                <td class="legacy"><code>honua convert</code> rewrites ArcGIS JS imports, FeatureLayer constructors, portal references, and styles to <code>@honua/sdk</code>.</td>
-                <td class="honua">App migrations stop being rewrite projects. ~85–95% automated; judgment calls flagged.</td>
+                <td class="legacy"><code>honua-migrate codemod</code> rewrites ArcGIS JS imports, FeatureLayer / MapView / Query / reactiveUtils constructors and call sites to <code>@honua/sdk-esri-compat</code>; .NET / Python / MAUI converters are on the roadmap.</td>
+                <td class="honua">App migrations stop being rewrite projects. Auto-migration ratio is emitted per-run in the parity report; remaining call sites carry a <code>TODO(honua-migrate)</code> marker for review.</td>
               </tr>
               <tr>
                 <td class="area">GeoServer service import</td>

--- a/open-core.html
+++ b/open-core.html
@@ -95,7 +95,7 @@
               <tr><td class="area">Compute</td><td class="legacy">Peak-sized 24/7. Underused at night.</td><td class="honua">Elastic. Your cloud bill scales with traffic.</td></tr>
               <tr><td class="area">Commercial tier</td><td class="legacy">Bundled SKUs with overlap and gating.</td><td class="honua">Pro and Enterprise tiers · capability baseline at enterpriseready.io.</td></tr>
               <tr><td class="area">Support</td><td class="legacy">Vendor contract, annual.</td><td class="honua">Shaping support model with early customers.</td></tr>
-              <tr><td class="area">Migration</td><td class="legacy">Replatform + app-rewrite project.</td><td class="honua">Service import + <code>honua convert</code> · included path.</td></tr>
+              <tr><td class="area">Migration</td><td class="legacy">Replatform + app-rewrite project.</td><td class="honua">Service import + <code>honua-migrate codemod</code> · included path.</td></tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary

Original change: update the homepage \`index.html\` terminal block to use the real CLI (\`honua-migrate\` not \`honua\`, \`@honua/sdk-esri-compat\` not \`@honua/sdk\`, real subcommands).

Expanded to bundle the rest of the site audit per request. Touches \`docs.html\`, \`interoperability.html\`, \`migration.html\`, \`open-core.html\` to fix:

- **CLI everywhere**: \`honua convert js|dotnet|python|maui\` and \`honua parity --against\` don't exist. Real binary is \`honua-migrate\`; real verbs are \`scan\` / \`codemod\` / \`matrix\` / \`fixtures\` / \`reconcile\` / \`demo\` / \`content *\` (see \`honua-sdk-js/src/migration/cli.ts:1645\`).
- **Wrong package name**: \`@honua/sdk\` → \`@honua/sdk-esri-compat\` (the real \`DEFAULT_COMPAT_IMPORT_PATH\`). Affects \`interoperability.html\`, \`migration.html\`, \`open-core.html\`.
- **Python import**: \`docs.html\` now shows \`from honua_sdk import HonuaClient\` (the real package).
- **iOS + Android row removed** from \`interoperability.html\` — those repos don't exist; mobile is .NET MAUI only.
- **.NET / Python / MAUI converter cards** demoted from "production tooling" to "roadmap" on \`migration.html\` — only the JS codemod ships today.
- **Invented URL aliases** like \`/services/features/Parcels/v1/0\` replaced with the real Honua-Server route \`/rest/services/Parcels/FeatureServer/0\`.
- **\`~85–95% automated\` claim removed** in favor of the actual marker the tool emits: \`TODO(honua-migrate)\` (honors \`claims.html\` rule 01 — exact numbers need CITE evidence).
- **Diff example** in \`migration.html\` now shows real Compat-suffixed classes (\`MapCompat\`, \`MapViewCompat\`, \`FeatureLayerCompat\`).

\`claims.html\`, \`cloud-native.html\`, \`operations.html\`, \`performance.html\`, \`privacy.html\`, \`security.html\`, \`ai-gis.html\` audited and found accurate; no changes.

## Test plan

- [x] Every HTML page still parses (\`HTMLParser\`).
- [x] \`grep\` confirms no \`honua convert\`, no \`honua parity\`, no bare \`@honua/sdk\`, no \`~85–95%\`, no \`iOS + Android\` SDK references remain.
- [ ] Open each touched page locally and confirm the layout still fits the CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)