### PR TITLE
[codex] Align testing evidence claims with current gaps

### DIFF
--- a/claims.html
+++ b/claims.html
@@ -45,7 +45,7 @@
           <h1 style="max-width: none;">Every claim has a <span class="teal">receipt.</span></h1>
           <p class="bed-lede" style="max-width: 720px;">
             This page is the site-owned review surface for public messaging. Each major claim category maps to
-            shipped source evidence, preview proof, an owner ticket, or an explicit deferred status — before broad outreach.
+            shipped source evidence, preview proof, a scoped caveat, or an owner ticket — before broad outreach.
           </p>
           <div class="evidence-scoreboard">
             <div class="evidence-stat">
@@ -124,9 +124,9 @@
               </tr>
               <tr id="migration-cutover">
                 <td class="area">Migration wedge &amp; cutover automation</td>
-                <td class="legacy">Frame import, parity, reconciliation, and cutover as pilot-scoped or proof-pending until migration evidence is linked. No unconditional "clients keep working" or "cut over when ready" claims.</td>
-                <td class="honua"><span class="evidence-badge blue">Proof pending</span></td>
-                <td class="honua"><a href="https://github.com/honua-io/honua-server/issues/646" target="_blank" rel="noopener noreferrer">honua-server#646</a></td>
+                <td class="legacy">Say scoped migration evidence exists for supported source families, parity checks, and measured migration-performance fixtures. Keep cutover, SDK-driven migration, and ArcPy/Python GP caveats visible until those release artifacts are attached.</td>
+                <td class="honua"><span class="evidence-badge amber">Preview partial</span></td>
+                <td class="honua"><a href="https://github.com/honua-io/honua-server/blob/trunk/docs/contributor/compatibility-and-migration-evidence.md" target="_blank" rel="noopener noreferrer">Compatibility &amp; migration evidence</a></td>
               </tr>
               <tr id="grpc-sdks">
                 <td class="area">gRPC &amp; SDKs</td>

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -68,12 +68,12 @@ Supporting pages should only change when needed for nav consistency, CTA routing
 The `proof-and-gtm-buyer-path` release lane spans multiple repositories. For `honua-site#1`, site-owned work is limited to IA, CTA routing, and attribution. The remaining release-lane gaps stay bounded to their owning tickets:
 
 - `honua-site#3`: CRM/marketplace handoff wiring, monitoring, and alerting beyond the static FormSubmit MVP.
-- `honua-site#9`: proof hub that publishes benchmarks, compatibility matrix, migration evidence, and reference architecture after source assets are supplied.
+- `honua-site#9`: proof hub that publishes benchmarks, compatibility matrix, migration evidence, and reference architecture as source assets become release-backed.
 - `honua-site#17`: public claims matrix mapping every site claim to source, proof, or roadmap status.
 - `honua-marketplace#3`: marketplace handoff target, offer/listing package, activation, and publish evidence.
 - `honua-sales#4`, `honua-sales#5`, `honua-sales#6`, `honua-sales#18`, and `honua-sales#25`: pricing, pilot packaging, sales handoff model, roles, SLAs, escalation, and content-owner commitments.
 - `honua-sales#42`: end-to-end buyer-path acceptance from site CTA to marketplace deployment to first service publish.
-- `honua-sdk-js#70`: SDK capability matrix and sample-harness evidence consumed by site proof surfaces.
+- SDK repos: SDK capability matrices, sample-harness evidence, and SDK-driven migration evidence consumed by site proof surfaces.
 - `honua-showcase`: repeatable demo flow used by pilot and sales motions.
 
 ## Boundary

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
         <div class="compat-grid">
           <div class="compat-col">
             <span class="group">GeoServices REST · Esri-compatible</span>
-            <p class="note">Honua Server speaks GeoServices REST as a first-class protocol, hosted on open infrastructure. Esri-compatible clients can point at a Honua endpoint and keep working — same wire protocol, same response shapes. Parity is scoped per service; see the <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/geoservices-rest-parity.md" target="_blank" rel="noopener noreferrer">parity matrix</a> for current coverage.</p>
+            <p class="note">Honua Server speaks GeoServices REST as a first-class protocol, hosted on open infrastructure. Covered Esri-compatible clients can point at a Honua endpoint for the scoped wire protocols and response shapes in the parity matrix; see the <a class="text-link" href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/geoservices-rest-parity.md" target="_blank" rel="noopener noreferrer">parity matrix</a> for current coverage.</p>
             <div class="chips">
               <div class="chip"><span class="dot"></span>FeatureServer<span class="ok mono">✓</span></div>
               <div class="chip"><span class="dot"></span>MapServer<span class="ok mono">✓</span></div>
@@ -150,7 +150,7 @@
 
           <div class="compat-col">
             <span class="group">SDKs · parity by design</span>
-            <p class="note">Each Honua SDK is shaped to match its Esri counterpart 1:1 — a compatibility-by-design surface, not a fork. Convert existing apps with the <span class="mono" style="color: var(--bed-text);">honua convert</span> codemod — no rewrite by hand.</p>
+            <p class="note">Each Honua SDK is shaped around familiar GIS workflows — a compatibility-by-design surface, not a fork. Convert supported app surfaces with the <span class="mono" style="color: var(--bed-text);">honua convert</span> codemod and keep review markers where automation cannot prove parity.</p>
             <div class="chips">
               <div class="chip"><span class="dot"></span>JavaScript SDK<span class="ok mono">✓</span></div>
               <div class="chip"><span class="dot"></span>Python SDK<span class="ok mono">✓</span></div>

--- a/interoperability.html
+++ b/interoperability.html
@@ -47,9 +47,9 @@
           <span class="eyebrow">// pillar 01 · compatibility</span>
           <h1>Speaks GeoServices REST.<br />Speaks OGC.<br /><span class="teal">SDK parity by design.</span></h1>
           <p class="bed-lede">
-            Your clients keep working — same wire protocol, same response shapes. Your code keeps using the
-            SDK surfaces your team already targets. Your data keeps living where it already does. Honua keeps
-            the surface; reshapes everything underneath.
+            Covered clients can stay on the scoped wire protocols and response shapes documented in
+            the evidence ledger. Your code can stay on familiar SDK surfaces while Honua keeps the public
+            contract and reshapes the infrastructure underneath.
           </p>
           <div class="cta-row">
             <a class="btn btn-primary" href="mailto:info@honua.io">Talk to us</a>
@@ -59,7 +59,7 @@
         </div>
 
         <div class="bed-map-panel">
-          <div class="head">URL &amp; SDK mapping · drop-in</div>
+          <div class="head">URL &amp; SDK mapping · scoped parity</div>
           <div class="grp">
             <div class="gh">Service endpoints</div>
             <div class="row"><span class="from">/arcgis/rest/services/Parcels/FeatureServer/0</span><span class="arrow">→</span><span class="to">/rest/services/Parcels/FeatureServer/0</span></div>
@@ -87,7 +87,7 @@
         <div class="bed-proof">
           <div class="bed-proof-card">
             <div class="ph"><span class="gh">GeoServices REST · partial parity</span><span class="live amber">PARTIAL</span></div>
-            <span class="gt">Drop-in for the Esri-compatible surface.</span>
+            <span class="gt">Drop-in where the scoped Esri-compatible surface is covered.</span>
             <p class="gp">Honua's GeoServices REST surface targets FeatureServer, MapServer, ImageServer, Geometry Service, and GPServer. Parity is scoped per service — what's covered, what's pending, and what's deferred is recorded in the parity matrix and JSON data file in <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua-server</code>.</p>
             <div class="rows">
               <div class="pr"><span class="nm">FeatureServer</span><span class="ct">supported · gaps tracked</span></div>
@@ -118,7 +118,7 @@
           <div class="bed-proof-card">
             <div class="ph"><span class="gh">SDK · parity by design</span><span class="live">EVIDENCED</span></div>
             <span class="gt">Compatibility-by-design surface.</span>
-            <p class="gp">Each Honua SDK is shaped to match its Esri counterpart 1:1 — not a fork. Conversion happens through the <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua-migrate codemod</code> on the JavaScript SDK today; other languages ship their parity surface and gain codemod coverage on the roadmap.</p>
+            <p class="gp">Each Honua SDK is shaped around familiar GIS workflows — not a fork. Conversion happens through the <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua-migrate codemod</code> on the JavaScript SDK today; other languages ship their parity surface and gain codemod coverage on the roadmap.</p>
             <div class="rows">
               <div class="pr"><span class="nm">JavaScript SDK</span><span class="ct"><span class="ok">✓</span>deterministic 2D parity</span></div>
               <div class="pr"><span class="nm">Python SDK</span><span class="ct"><span class="ok">✓</span>parity surface</span></div>


### PR DESCRIPTION
## Summary

Aligns public site copy with the current testing and conformance evidence instead of overclaiming full drop-in parity.

## Changes

- Softens migration/cutover claims to scoped preview language.
- Removes over-strong SDK and wire-protocol parity phrasing.
- Points migration evidence copy at the current compatibility and migration evidence docs.

## Validation

- `./scripts/build-dist.sh` passed.
- `git diff --check` passed.
