### PR TITLE
feat: hs-1: Publish Honua QGIS plugin landing page (#honua-site-26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Repository layout:
 - `interoperability.html` - standards, file, database, gRPC, and MCP compatibility
 - `performance.html` - performance architecture and GeoBench entry points
 - `ai-gis.html` - AI-ready GIS workflows and MCP surface
+- `qgis-plugin.html` - Honua GIS Assistant QGIS plugin landing, install path, media status, and privacy boundary
 - `migration.html` - easy adoption and migration paths
 - `platform.html` - platform overview
 - `protocols.html` - protocol surface and compatibility story

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Static site extracted from `honua-io/honua-server` (issue #336).
 
 Current site sections and operational features are summarized in [docs/features/README.md](docs/features/README.md).
 
+QGIS plugin page contract:
+- `qgis-plugin.html` is the site-owned static landing page for Honua GIS Assistant at `https://honua.io/qgis-plugin.html`.
+- The page links to the external `honua-io/honua-qgis-plugin` source and releases, but this repository does not own the plugin ZIP, QGIS marketplace listing, screenshots, demo video, or plugin-local privacy documentation.
+- Keep `qgis-plugin.html` and `claims.html#qgis-plugin` aligned: 0.1.0 early preview, GPL-2.0-or-later, QGIS 3.34+, release ZIP/media/marketplace approval pending, local-first account-free defaults, no plugin telemetry, and no QGIS project endorsement claim.
+
 Repository layout:
 - `index.html` - minimal homepage and contact entry points
 - `cloud-native.html` - modern cloud-native platform proof points

--- a/ai-gis.html
+++ b/ai-gis.html
@@ -170,17 +170,17 @@
             <span class="b">Esri-compatible service surface, OGC standards, and SDKs.</span>
             <span class="more">Read pillar 01</span>
           </a>
+          <a class="bed-related-card" href="qgis-plugin.html">
+            <span class="n">qgis</span>
+            <span class="t">Honua QGIS Plugin</span>
+            <span class="b">Early-preview local assistant workflow for QGIS with explicit privacy boundaries.</span>
+            <span class="more">Open plugin page</span>
+          </a>
           <a class="bed-related-card" href="operations.html">
             <span class="n">05</span>
             <span class="t">Simple operations</span>
             <span class="b">Terraform, OpenTelemetry, and GitOps.</span>
             <span class="more">Read pillar 05</span>
-          </a>
-          <a class="bed-related-card" href="performance.html">
-            <span class="n">06</span>
-            <span class="t">High performance</span>
-            <span class="b">AOT-compiled engine, benchmarked, cloud-optimized.</span>
-            <span class="more">Read pillar 06</span>
           </a>
         </div>
       </section>

--- a/claims.html
+++ b/claims.html
@@ -146,6 +146,12 @@
                 <td class="honua"><span class="evidence-badge amber">Preview partial</span></td>
                 <td class="honua"><a href="https://github.com/honua-io/geospatial-mcp" target="_blank" rel="noopener noreferrer">geospatial-mcp</a></td>
               </tr>
+              <tr id="qgis-plugin">
+                <td class="area">QGIS plugin</td>
+                <td class="legacy">Describe Honua GIS Assistant as a 0.1.0 early-preview, GPL-2.0-or-later QGIS plugin for private/local assisted workflows with local Ollama chat, audit JSONL, default-off remote endpoint settings, and a bounded query bridge. Keep release ZIP, marketplace approval, screenshots, and demo video marked pending until those artifacts ship. Preserve local-first, no-account, no-telemetry defaults. Do not claim QGIS project endorsement or certification.</td>
+                <td class="honua"><span class="evidence-badge amber">Preview partial</span> <span class="evidence-badge gray">External owner</span></td>
+                <td class="honua"><a href="https://github.com/honua-io/honua-qgis-plugin" target="_blank" rel="noopener noreferrer">honua-qgis-plugin</a></td>
+              </tr>
               <tr id="mobile-field">
                 <td class="area">Mobile · field · offline · MAUI</td>
                 <td class="legacy">Label as Beta or pilot-scoped. Do not present offline sync, conflict handling, or device workflows as Preview-ready.</td>

--- a/docs.html
+++ b/docs.html
@@ -107,6 +107,7 @@ PY</code></pre>
         <li>Read the <a href="migration.html">Low risk migration</a> pillar for the import + converter flow.</li>
         <li>Read the <a href="cloud-native.html">Cloud-native</a> pillar and grab the <a href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">Terraform module</a> when you want a real deployment.</li>
         <li>Read the <a href="operations.html">Simple operations</a> pillar for OpenTelemetry, OIDC, and the GitOps loop.</li>
+        <li>Open the <a href="qgis-plugin.html">Honua QGIS Plugin</a> page for the early-preview QGIS assistant install path and local-first privacy boundary.</li>
         <li>Check the <a href="claims.html">Claims matrix</a> for the wording rules that govern every public number on this site.</li>
       </ul>
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -43,6 +43,19 @@ Supporting/detail pages:
 
 Supporting pages should only change when needed for nav consistency, CTA routing, claim alignment, or proof linking. They are not separate conversion endpoints for this MVP.
 
+## QGIS Plugin Page Contract
+
+`qgis-plugin.html` is a static top-level page served through the same static build and `_headers` contract as the rest of the site. The canonical URL is `https://honua.io/qgis-plugin.html`; `scripts/build-dist.sh` picks it up automatically because it copies top-level HTML files into `dist/`.
+
+Public wording for the page must stay aligned with `claims.html#qgis-plugin`:
+
+- Status: Honua GIS Assistant is a `0.1.0` early-preview, GPL-2.0-or-later QGIS plugin targeting QGIS 3.34+.
+- Implemented behavior: toolbar/menu entry, right-docked chat/control panel, local Ollama model refresh, streamed generation with cancellation, local audit JSONL controls, default-off remote endpoint settings, and a bounded PyQGIS vector-layer query bridge.
+- Install contract: direct end-user install copy points to the GitHub Releases ZIP only after `honua-qgis-plugin` publishes one. Until then, this site links to the source repository and release page and keeps release ZIP, QGIS marketplace approval, screenshots, demo poster, and demo video marked pending.
+- Privacy boundary: local use requires no Honua account and sends no plugin analytics, crash reports, prompts, responses, project files, layer data, or audit records to Honua. Local model calls go only to the configured Ollama endpoint. Remote OpenAI-compatible endpoints are opt-in and governed by the endpoint operator's terms.
+- Site telemetry: QGIS plugin page CTAs use the existing consent-gated `cta_click` link attributes. Analytics absence or failure must not block repository, release, anchor, or contact navigation.
+- Media contract: production screenshots and native video assets should be committed under `assets/qgis-plugin/` only after the plugin owner supplies release-matched proof media. Avoid third-party embeds unless CSP and privacy copy are deliberately updated.
+
 ## Content Ownership
 
 - `honua-site`: static IA, navigation, CTA placement, contact-form fields, privacy/security/terms site copy, analytics hook points, and links to proof assets.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -35,6 +35,7 @@ Supporting/detail pages:
 
 - `platform.html`: platform overview for users who want the broad architecture.
 - `agentic-gis.html`: AI-agent and MCP detail page.
+- `qgis-plugin.html`: early-preview Honua GIS Assistant QGIS plugin landing page, bounded to source/release/media artifacts owned by `honua-qgis-plugin`.
 - `runtime.html`: gRPC/runtime detail page.
 - `devops.html`: GitOps, observability, and operations detail page.
 - `sdks.html`: SDK detail page.
@@ -46,6 +47,7 @@ Supporting pages should only change when needed for nav consistency, CTA routing
 
 - `honua-site`: static IA, navigation, CTA placement, contact-form fields, privacy/security/terms site copy, analytics hook points, and links to proof assets.
 - `honua-server`: runtime, protocol, compatibility, deployment, migration, and operator evidence consumed by public pages.
+- `honua-qgis-plugin`: QGIS plugin source, release ZIP, marketplace approval, screenshots, demo video, install source of truth, and plugin-local privacy documentation consumed by `qgis-plugin.html`.
 - SDK repos: SDK capability matrices, examples, and sample-harness evidence consumed by site proof surfaces.
 - `honua-marketplace`: marketplace URL, offer/listing package, entitlement activation proof, and publish evidence.
 - `honua-sales`: pricing, pilot packaging, sales handoff model, commercial terms, roles, SLAs, escalation, and content-owner commitments.
@@ -76,6 +78,7 @@ The `proof-and-gtm-buyer-path` release lane spans multiple repositories. Site-ow
 - `honua-sales#42`: end-to-end buyer-path acceptance from site CTA to marketplace deployment to first service publish.
 - SDK repos: SDK capability matrices, sample-harness evidence, and SDK-driven migration evidence consumed by site proof surfaces.
 - `honua-showcase`: repeatable demo flow used by pilot and sales motions.
+- `honua-qgis-plugin`: release ZIP, QGIS marketplace approval, production screenshots, demo poster/video, and final download URL for the QGIS plugin landing page.
 
 ## Boundary
 

--- a/qgis-plugin.html
+++ b/qgis-plugin.html
@@ -1,0 +1,425 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua QGIS Plugin | Honua</title>
+    <meta name="description" content="Honua GIS Assistant is an early-preview, GPL-2.0-or-later QGIS plugin for private/local assisted GIS workflows." />
+    <meta property="og:title" content="Honua QGIS Plugin | Honua" />
+    <meta property="og:description" content="Early-preview QGIS assistant with local Ollama chat, audit JSONL, remote mode off by default, and a bounded PyQGIS query bridge." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://honua.io/qgis-plugin.html" />
+    <meta property="og:image" content="https://honua.io/assets/og-image.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Honua QGIS Plugin | Honua" />
+    <meta name="twitter:description" content="Local-first, account-free QGIS assistant workflow in v0 preview." />
+    <meta name="twitter:image" content="https://honua.io/assets/og-image.png" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.google-analytics.com https://honua.io; form-action 'self' https://formsubmit.co; upgrade-insecure-requests" />
+    <script defer src="assets/analytics.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="canonical" href="https://honua.io/qgis-plugin.html" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="bed-nav">
+      <a class="brand" href="index.html" aria-label="Honua home">
+        <img src="assets/honua-logo.svg" alt="" aria-hidden="true" />
+        <span class="wm">Honua</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+      <nav class="nav-groups" aria-label="Primary">
+        <a href="interoperability.html">Compatibility</a>
+        <a href="migration.html">Low risk migration</a>
+        <a href="open-core.html">Predictable cost</a>
+        <a href="cloud-native.html">Cloud-native</a>
+        <a href="operations.html">Simple operations</a>
+        <a href="performance.html">Performance</a>
+        <a href="ai-gis.html">AI-ready</a>
+        <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="qgis_plugin_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="bed-hero">
+        <div class="hex-bg" aria-hidden="true"></div>
+        <div style="position: relative;">
+          <span class="eyebrow">// qgis plugin · v0 preview</span>
+          <h1>Honua QGIS Plugin.<br /><span class="teal">Local-first GIS assistant workflows.</span></h1>
+          <p class="bed-lede">
+            Honua GIS Assistant is an early-preview QGIS plugin for private/local assisted GIS workflows.
+            The current <strong>0.1.0</strong> build ships a toolbar action, right-docked chat/control panel,
+            local Ollama model refresh, streamed generation, cancellation, local audit JSONL, default-off remote
+            endpoint settings, and a bounded PyQGIS query bridge.
+          </p>
+          <p class="bed-lede">
+            The plugin is self-contained, <strong>GPL-2.0-or-later</strong>, and account-free for local use. It sends no
+            network telemetry; local model calls go only to the configured Ollama endpoint, and remote calls happen only
+            when an operator intentionally enables a non-local endpoint.
+          </p>
+          <div class="cta-row">
+            <a
+              class="btn btn-primary"
+              href="https://github.com/honua-io/honua-qgis-plugin"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-analytics-event="cta_click"
+              data-analytics-label="qgis_plugin_repo"
+              data-analytics-destination="https://github.com/honua-io/honua-qgis-plugin"
+            >View GPL repo</a>
+            <a
+              class="btn btn-ghost"
+              href="https://github.com/honua-io/honua-qgis-plugin/releases"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-analytics-event="cta_click"
+              data-analytics-label="qgis_plugin_releases"
+              data-analytics-destination="https://github.com/honua-io/honua-qgis-plugin/releases"
+            >Check releases</a>
+            <a
+              class="btn btn-ghost"
+              href="#install"
+              data-analytics-event="cta_click"
+              data-analytics-label="qgis_plugin_install_anchor"
+              data-analytics-destination="qgis-plugin.html#install"
+            >Install path</a>
+            <a
+              class="btn btn-ghost"
+              href="#media"
+              data-analytics-event="cta_click"
+              data-analytics-label="qgis_plugin_media_anchor"
+              data-analytics-destination="qgis-plugin.html#media"
+            >Media status</a>
+            <span class="cta-meta">release ZIP and demo media are pending owner handoff</span>
+          </div>
+        </div>
+
+        <div class="plugin-status-panel" aria-label="Honua QGIS plugin status">
+          <div class="plugin-status-head">
+            <span>honua_gis_assistant</span>
+            <span class="pending">EARLY PREVIEW</span>
+          </div>
+          <div class="plugin-status-body">
+            <div class="plugin-status-row">
+              <span>Plugin repo</span>
+              <a href="https://github.com/honua-io/honua-qgis-plugin" target="_blank" rel="noopener noreferrer">honua-io/honua-qgis-plugin</a>
+            </div>
+            <div class="plugin-status-row">
+              <span>License</span>
+              <strong>GPL-2.0-or-later</strong>
+            </div>
+            <div class="plugin-status-row">
+              <span>Current version</span>
+              <strong>0.1.0 preview</strong>
+            </div>
+            <div class="plugin-status-row">
+              <span>QGIS target</span>
+              <strong>3.34+</strong>
+            </div>
+            <div class="plugin-status-row">
+              <span>Release ZIP</span>
+              <strong>Pending GitHub Release</strong>
+            </div>
+            <div class="plugin-status-row">
+              <span>Current UI</span>
+              <strong>Docked chat/control panel</strong>
+            </div>
+            <div class="plugin-status-row">
+              <span>Implemented bridge</span>
+              <strong>Vector-layer query</strong>
+            </div>
+            <div class="plugin-status-row">
+              <span>Default privacy</span>
+              <strong>Local-first, no telemetry</strong>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="media" class="bed-pillar-detail">
+        <div class="section-head">
+          <span class="eyebrow">// screenshots &amp; demo</span>
+          <h2>Proof media stays tied to released behavior.</h2>
+          <p class="sub">
+            The plugin repository defines the screenshot targets, but the binary screenshots, demo poster, and demo video
+            are not published yet. This page keeps the public media slots visible without inventing product proof.
+          </p>
+        </div>
+
+        <div class="plugin-media-grid" aria-label="Planned QGIS plugin screenshots">
+          <figure class="plugin-media-card is-pending">
+            <div class="plugin-media-placeholder" role="img" aria-label="Pending screenshot: docked local chat panel running a local Ollama model">
+              <span>01</span>
+              <strong>Local chat panel</strong>
+            </div>
+            <figcaption>Pending screenshot: docked chat panel with a local Ollama model selected. Capture after release media handoff.</figcaption>
+          </figure>
+          <figure class="plugin-media-card is-pending">
+            <div class="plugin-media-placeholder" role="img" aria-label="Pending screenshot: vector query result table over sample QGIS data">
+              <span>02</span>
+              <strong>Query result preview</strong>
+            </div>
+            <figcaption>Pending screenshot: the bounded <code>query</code> tool returning sample vector-layer attributes.</figcaption>
+          </figure>
+          <figure class="plugin-media-card is-pending">
+            <div class="plugin-media-placeholder" role="img" aria-label="Pending screenshot: remote endpoint settings with remote mode off by default">
+              <span>03</span>
+              <strong>Remote mode off</strong>
+            </div>
+            <figcaption>Pending screenshot: optional OpenAI-compatible endpoint settings with remote mode clearly off by default.</figcaption>
+          </figure>
+          <figure class="plugin-media-card is-pending">
+            <div class="plugin-media-placeholder" role="img" aria-label="Pending screenshot: local audit log settings and disable toggle">
+              <span>04</span>
+              <strong>Audit settings</strong>
+            </div>
+            <figcaption>Pending screenshot: local JSONL audit folder and enable/disable controls in the plugin UI.</figcaption>
+          </figure>
+        </div>
+
+        <div class="plugin-video-shell is-pending" aria-label="Demo video placeholder">
+          <div class="plugin-video-top">
+            <span>demo video</span>
+            <span>pending</span>
+          </div>
+          <div class="plugin-video-body">
+            <h3>Demo embed will publish when source media is supplied.</h3>
+            <p>
+              No self-hosted <code>.webm</code>, <code>.mp4</code>, or poster asset is currently available in this site
+              repository or the plugin repository. When supplied, it should be committed under
+              <code>assets/qgis-plugin/</code> and embedded with native <code>&lt;video controls preload="metadata"&gt;</code>.
+            </p>
+            <a
+              class="text-link"
+              href="https://github.com/honua-io/honua-qgis-plugin/tree/trunk/docs/marketplace/screenshots"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-analytics-event="cta_click"
+              data-analytics-label="qgis_plugin_media_source"
+              data-analytics-destination="https://github.com/honua-io/honua-qgis-plugin/tree/trunk/docs/marketplace/screenshots"
+            >View plugin media checklist</a>
+          </div>
+        </div>
+      </section>
+
+      <section id="install" class="bed-pillar-detail transparent">
+        <div class="section-head">
+          <span class="eyebrow">// install path</span>
+          <h2>Install through QGIS Plugin Manager once a ZIP is published.</h2>
+          <p class="sub">The public repository can build a QGIS-installable ZIP, but there is not yet a GitHub Release asset or approved QGIS Plugin Repository listing.</p>
+        </div>
+
+        <div class="row-2">
+          <div class="card-grid cols-1">
+            <div class="card">
+              <span class="lbl">01 · Requirements</span>
+              <div class="bd">Use QGIS <strong>3.34 or newer</strong>. The plugin is pure Python and uses the PyQt5/PyQGIS bindings shipped with QGIS.</div>
+            </div>
+            <div class="card">
+              <span class="lbl">02 · Get the ZIP</span>
+              <div class="bd">
+                For release installs, download <code>honua_gis_assistant-&lt;version&gt;.zip</code> from the
+                <a class="text-link" href="https://github.com/honua-io/honua-qgis-plugin/releases" target="_blank" rel="noopener noreferrer">GitHub Releases page</a>
+                once the release owner attaches it. Until then, the source repo is the handoff point.
+              </div>
+            </div>
+            <div class="card">
+              <span class="lbl">03 · Install from ZIP</span>
+              <div class="bd">In QGIS, open <strong>Plugins -&gt; Manage and Install Plugins -&gt; Install from ZIP</strong>, select the downloaded archive, and enable <strong>Honua GIS Assistant</strong>.</div>
+            </div>
+            <div class="card">
+              <span class="lbl">04 · Open the panel</span>
+              <div class="bd">Use <strong>Plugins -&gt; Honua GIS Assistant -&gt; Show Panel</strong>. The preview dock opens the local Ollama chat/control panel with model refresh, prompt streaming, cancellation, and local audit controls.</div>
+            </div>
+            <div class="card">
+              <span class="lbl">05 · Keep the endpoint explicit</span>
+              <div class="bd">Use local mode by leaving remote endpoints off. Configure only the operator-owned HTTP endpoint you intend to use; non-loopback Honua-compatible or OpenAI-compatible endpoints send context to that operator.</div>
+            </div>
+          </div>
+
+          <div class="code-block">
+            <div class="code-head">current release boundary</div>
+            <div class="code-body">
+              <div class="line"><span class="kw">status</span>: <span class="str">0.1.0 early preview</span></div>
+              <div class="line"><span class="kw">ships_now</span>: toolbar, menu, docked chat panel</div>
+              <div class="line"><span class="kw">bridge_now</span>: vector-layer query tool</div>
+              <div class="line"><span class="kw">model_calls_now</span>: local Ollama from QGIS UI</div>
+              <div class="line"><span class="kw">local_model_path</span>: Ollama over configured HTTP(S)</div>
+              <div class="line"><span class="kw">fallback_model</span>: qwen2.5-coder</div>
+              <div class="line"><span class="kw">future_preference</span>: Honua-GIS beta when available</div>
+              <div class="line"><span class="kw">remote_endpoints</span>: optional, off by default</div>
+              <div class="line"><span class="kw">release_zip</span>: pending GitHub Release</div>
+            </div>
+          </div>
+        </div>
+
+        <p class="footnote">
+          Maintainer builds use the plugin repository packager. This site intentionally avoids publishing local build commands as an end-user install path until a release artifact exists.
+        </p>
+      </section>
+
+      <section class="bed-pillar-detail">
+        <div class="section-head">
+          <span class="eyebrow">// privacy &amp; model boundary</span>
+          <h2>Anonymous and local-first by default.</h2>
+        </div>
+        <div class="bed-compat-expand">
+          <div class="bed-compat-card">
+            <span class="gh">Default mode</span>
+            <span class="gt">No Honua account required.</span>
+            <p class="gp">Local use does not require signup or a Honua login. The preview does not send analytics, crash reports, prompts, responses, project files, layer data, or audit records to Honua. Local model requests go only to the configured Ollama endpoint when the operator refreshes models or sends a prompt.</p>
+            <div class="gl">
+              <div class="it"><span>Account-free local use</span><span class="ok">v0</span></div>
+              <div class="it"><span>No network telemetry</span><span class="ok">default</span></div>
+            </div>
+          </div>
+          <div class="bed-compat-card">
+            <span class="gh">Local model path</span>
+            <span class="gt">Ollama stays on loopback.</span>
+            <p class="gp">The local generation path talks to a configured Ollama server over HTTP, defaulting to loopback. Until the Honua-GIS beta model is published, <code>qwen2.5-coder</code> is the documented fallback model.</p>
+            <div class="gl">
+              <div class="it"><span>Loopback HTTP boundary</span><span class="ok">implemented</span></div>
+              <div class="it"><span>Honua-GIS beta preference</span><span class="ok">future</span></div>
+            </div>
+          </div>
+          <div class="bed-compat-card">
+            <span class="gh">Remote mode</span>
+            <span class="gt">Operator-configured only.</span>
+            <p class="gp">Optional OpenAI-compatible remote endpoints are available, off by default, and change the privacy boundary. Remote usage is governed by the endpoint operator's terms, logging, retention, billing, and data-handling rules.</p>
+            <div class="gl">
+              <div class="it"><span>Remote endpoint calls</span><span class="ok">opt-in</span></div>
+              <div class="it"><span>Provider policy applies</span><span class="ok">operator-owned</span></div>
+            </div>
+          </div>
+        </div>
+        <p class="footnote">
+          See the site <a href="privacy.html">privacy notice</a> for honua.io analytics consent. The plugin's local-first privacy boundary is separate from this website's consent-gated analytics.
+        </p>
+      </section>
+
+      <section class="bed-pillar-detail transparent">
+        <div class="section-head">
+          <span class="eyebrow">// boundaries</span>
+          <h2>What this page does and does not claim.</h2>
+        </div>
+        <div class="table-wrap">
+          <table class="bed-data-table">
+            <thead>
+              <tr>
+                <th>Area</th>
+                <th>Current public wording</th>
+                <th>Boundary</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="area">Repository</td>
+                <td class="legacy">Dedicated public plugin repository under <code>honua-io/honua-qgis-plugin</code>.</td>
+                <td class="honua">GPL-2.0-or-later, self-contained plugin repo.</td>
+              </tr>
+              <tr>
+                <td class="area">Release</td>
+                <td class="legacy">0.1.0 early preview; release ZIP pending.</td>
+                <td class="honua">Do not say "download now" until a GitHub Release asset exists.</td>
+              </tr>
+              <tr>
+                <td class="area">QGIS endorsement</td>
+                <td class="legacy">QGIS 3.34+ plugin target.</td>
+                <td class="honua">No QGIS project endorsement, certification, or marketplace approval claim.</td>
+              </tr>
+              <tr>
+                <td class="area">Assistant behavior</td>
+                <td class="legacy">Docked local chat/control panel, local audit controls, remote endpoint settings, and bounded query bridge exist.</td>
+                <td class="honua">Do not claim QGIS Processing toolbox actions or marketplace approval.</td>
+              </tr>
+              <tr>
+                <td class="area">Model availability</td>
+                <td class="legacy"><code>qwen2.5-coder</code> fallback until Honua-GIS beta is available.</td>
+                <td class="honua">Do not imply a Honua-GIS model is bundled or auto-downloaded.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="footnote">Honua is not affiliated with, sponsored by, or endorsed by the QGIS project.</p>
+      </section>
+
+      <section class="bed-related">
+        <div class="label">// related paths</div>
+        <div class="bed-related-grid">
+          <a class="bed-related-card" href="docs.html#quickstart">
+            <span class="n">docs</span>
+            <span class="t">Run Honua locally</span>
+            <span class="b">Start the server, hit readiness, and make an authenticated SDK call.</span>
+            <span class="more">Open quickstart</span>
+          </a>
+          <a class="bed-related-card" href="ai-gis.html">
+            <span class="n">ai</span>
+            <span class="t">AI-ready GIS</span>
+            <span class="b">How Honua treats AI as a workflow primitive across analysis, maps, reports, and DevOps.</span>
+            <span class="more">Read the AI pillar</span>
+          </a>
+          <a class="bed-related-card" href="claims.html#qgis-plugin">
+            <span class="n">claims</span>
+            <span class="t">Public wording rule</span>
+            <span class="b">Preview and proof-media caveats for the QGIS plugin page.</span>
+            <span class="more">Open claims row</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="bed-cta-band">
+        <span class="eyebrow">// next</span>
+        <h2>Try the source.<br /><span class="teal">Keep the privacy boundary explicit.</span></h2>
+        <div class="row">
+          <a
+            class="btn btn-primary"
+            href="https://github.com/honua-io/honua-qgis-plugin"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-analytics-event="cta_click"
+            data-analytics-label="qgis_plugin_cta_repo"
+            data-analytics-destination="https://github.com/honua-io/honua-qgis-plugin"
+          >View plugin repo</a>
+          <a
+            class="btn btn-ghost"
+            href="index.html#contact"
+            data-analytics-event="cta_click"
+            data-analytics-label="qgis_plugin_contact"
+            data-analytics-destination="index.html#contact"
+          >Talk to us</a>
+        </div>
+      </section>
+    </main>
+
+    <footer id="contact" class="bed-footer">
+      <div class="footer-row">
+        <div class="left">
+          <img src="assets/honua-logo.svg" alt="" aria-hidden="true" />
+          <span class="mono">honua · /ˈhoʊnuə/ · earth</span>
+        </div>
+        <div class="links mono">
+          <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GITHUB</a>
+          <a href="docs.html">DOCS</a>
+          <a href="claims.html">CLAIMS</a>
+          <a href="security.html">SECURITY</a>
+          <a href="privacy.html">PRIVACY</a>
+          <a href="terms.html">TERMS</a>
+          <a href="mailto:info@honua.io">INFO@HONUA.IO</a>
+        </div>
+      </div>
+      <div class="footer-legal mono">
+        Esri®, ArcGIS®, ArcGIS Server®, ArcGIS Pro®, ArcGIS Runtime®, ArcGIS Online® and the ArcGIS JavaScript, .NET, Python, and Maps SDKs are trademarks of Environmental Systems Research Institute, Inc. Honua is not affiliated with, sponsored by, or endorsed by Esri.
+      </div>
+    </footer>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -736,6 +736,75 @@ img { max-width: 100%; height: auto; display: block; }
 .bed-mcp .call .key { color: var(--bed-blue); }
 .bed-mcp .call .str { color: var(--bed-teal-bright); }
 
+/* ── QGIS plugin landing page ───────────────────────── */
+.plugin-status-panel {
+  position: relative;
+  background: var(--bed-surface);
+  border: 1px solid var(--bed-rule);
+  border-radius: 10px;
+  box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+  overflow: hidden;
+  align-self: start;
+}
+.plugin-status-head {
+  display: flex; justify-content: space-between; gap: 12px; align-items: center;
+  padding: 12px 16px; border-bottom: 1px solid var(--bed-rule);
+  background: var(--bed-surface-2);
+  font-family: "Geist Mono", monospace; font-size: 11px; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--bed-text-dim);
+}
+.plugin-status-head .pending { color: var(--bed-amber); }
+.plugin-status-body { display: flex; flex-direction: column; }
+.plugin-status-row {
+  display: grid; grid-template-columns: 150px 1fr; gap: 14px;
+  padding: 12px 16px; border-bottom: 1px solid var(--bed-rule);
+  font-size: 13px; align-items: baseline;
+}
+.plugin-status-row:last-child { border-bottom: 0; }
+.plugin-status-row span { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--bed-text-faint); letter-spacing: 0.04em; text-transform: uppercase; }
+.plugin-status-row strong, .plugin-status-row a { color: var(--bed-text); font-weight: 500; min-width: 0; overflow-wrap: anywhere; }
+.plugin-status-row a { color: var(--bed-teal-bright); text-decoration: underline; text-underline-offset: 2px; }
+
+.plugin-media-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 24px; }
+.plugin-media-card {
+  margin: 0; background: var(--bed-bg); border: 1px solid var(--bed-rule);
+  border-radius: 10px; overflow: hidden; display: flex; flex-direction: column;
+}
+.plugin-media-placeholder {
+  aspect-ratio: 16 / 10;
+  min-height: 150px;
+  padding: 18px;
+  display: flex; flex-direction: column; justify-content: flex-end; gap: 6px;
+  background:
+    linear-gradient(135deg, rgba(95,161,204,0.16), rgba(58,160,136,0.08)),
+    radial-gradient(circle at 16px 16px, var(--bed-rule) 0.8px, transparent 1.2px);
+  background-size: auto, 18px 18px;
+  border-bottom: 1px solid var(--bed-rule);
+}
+.plugin-media-placeholder span {
+  font-family: "Geist Mono", monospace; font-size: 11px; color: var(--bed-amber);
+  letter-spacing: 0.14em; text-transform: uppercase;
+}
+.plugin-media-placeholder strong { font-size: 18px; color: var(--bed-text); letter-spacing: 0; }
+.plugin-media-card figcaption { padding: 14px 16px 16px; font-size: 12.5px; line-height: 1.55; color: var(--bed-text-dim); }
+.plugin-media-card code { font-family: "Geist Mono", monospace; font-size: 12px; color: var(--bed-text); background: var(--bed-surface-2); border: 1px solid var(--bed-rule); border-radius: 4px; padding: 1px 5px; }
+
+.plugin-video-shell {
+  background: var(--bed-bg); border: 1px solid var(--bed-rule); border-radius: 10px;
+  overflow: hidden;
+}
+.plugin-video-top {
+  display: flex; justify-content: space-between; gap: 12px; padding: 11px 16px;
+  background: var(--bed-surface-2); border-bottom: 1px solid var(--bed-rule);
+  font-family: "Geist Mono", monospace; font-size: 11px; color: var(--bed-text-dim);
+  letter-spacing: 0.12em; text-transform: uppercase;
+}
+.plugin-video-top span:last-child { color: var(--bed-amber); }
+.plugin-video-body { min-height: 260px; padding: 28px; display: flex; flex-direction: column; justify-content: center; }
+.plugin-video-body h3 { margin: 0 0 10px; font-size: 24px; line-height: 1.15; letter-spacing: 0; color: var(--bed-text); }
+.plugin-video-body p { max-width: 720px; color: var(--bed-text-dim); line-height: 1.6; margin: 0 0 14px; }
+.plugin-video-body code { font-family: "Geist Mono", monospace; font-size: 12.5px; color: var(--bed-text); background: var(--bed-surface-2); border: 1px solid var(--bed-rule); border-radius: 4px; padding: 1px 6px; }
+
 /* ── primitives grid (cloud-native) ──────────────────── */
 .bed-prim-grid {
   display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px;
@@ -790,8 +859,13 @@ img { max-width: 100%; height: auto; display: block; }
   .bed-ops { grid-template-columns: 1fr; }
   .bed-ops-tile.full { grid-column: auto; }
   .bed-prim-grid { grid-template-columns: 1fr; }
+  .plugin-media-grid { grid-template-columns: repeat(2, 1fr); }
+  .plugin-status-row { grid-template-columns: 130px 1fr; }
 }
 @media (max-width: 640px) {
   .bed-pillar-detail { padding: 48px 18px; }
   .bed-related { padding: 40px 18px; }
+  .plugin-media-grid { grid-template-columns: 1fr; }
+  .plugin-status-head, .plugin-status-row { grid-template-columns: 1fr; }
+  .plugin-video-body { min-height: 220px; padding: 22px; }
 }


### PR DESCRIPTION
# Pull Request

## Issue Link

Fixes #26
## Summary

Added the static Honua QGIS Plugin landing page at [qgis-plugin.html](/home/makani/worktrees/honua-site/honua-site-26/qgis-plugin.html:1). It uses the existing head/CSP, header/footer, analytics CTA attributes, responsive static layout, and shared CSS patterns.

The page is honest about the current `0.1.0` preview state: repo/source CTA, release ZIP pending, placeholder media slots, QGIS install path, local-first privacy boundary, `qwen2.5-coder` fallback wording, and no QGIS endorsement claim.
## Changes Made

- Added the static Honua QGIS Plugin landing page at [qgis-plugin.html](/home/makani/worktrees/honua-site/honua-site-26/qgis-plugin.html:1). It uses the existing head/CSP, header/footer, analytics CTA attributes, responsive static layout, and shared CSS patterns.
- The page is honest about the current `0.1.0` preview state: repo/source CTA, release ZIP pending, placeholder media slots, QGIS install path, local-first privacy boundary, `qwen2.5-coder` fallback wording, and no QGIS endorsement claim.
## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Architecture tests pass
- [x] Local pre-PR validation passed (`scripts/pre-pr-check.sh`)
## Gate Impact

- [x] PR gates (build, test, governance)
- [ ] Nightly gates (conformance, performance, security)
- [ ] Release gates (packaging, publishing)
- [ ] Deploy gates (promotion, post-apply validation)
- [ ] None — no gate impact
## Docs or Contract Impact

- [ ] OpenAPI spec changed
- [ ] Protobuf/gRPC contract changed
- [ ] Control plane SDK surface changed
- [ ] Documentation updated
- [x] None — no docs or contract impact
## Release/Deploy Impact

- [ ] Requires coordinated release across repos
- [ ] Requires database migration
- [ ] Requires infrastructure changes
- [ ] Requires environment variable or secret changes
- [x] None — standard merge-and-release flow
## Breaking Changes

None
## Pre-PR Checklist

- [x] Ran `scripts/pre-pr-check.sh` and all checks passed
- [ ] Commit messages follow conventional format: `type: description (#issue)`
- [ ] PR title matches main commit message
- [x] Issue number linked above
- [ ] Tests added for new functionality
- [ ] If protocol/auth behavior changed: updated compatibility contract
- [ ] If breaking admin/control-plane API changes: updated migration guide
- [ ] If breaking gRPC/proto wire changes: confirmed with explicit review
## Coverage Impact

- Line coverage: Not measured locally
- Branch coverage: Not measured locally
## Additional Context

Decisions:
Kept the page in preview mode instead of claiming a download-ready release. Used visible placeholders for screenshots/demo video because the real release ZIP and production media are not available in this repo.

Follow-ons:
Create bounded `honua-qgis-plugin` child tickets for GitHub Release ZIP, QGIS marketplace approval/final URL, production screenshots, demo poster/video, and final public download URL.

Code kaizen:
Auto-deferred by kaizen policy.
