### PR TITLE
docs: add claims-safe Honua-GIS status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Repository layout:
 - `performance.html` - performance architecture and GeoBench entry points
 - `ai-gis.html` - AI-ready GIS workflows and MCP surface
 - `qgis-plugin.html` - Honua GIS Assistant QGIS plugin landing, install path, media status, and privacy boundary
+- `honua-gis.html` - Honua-GIS model/eval announcement, status table, and quickstart gates
 - `migration.html` - easy adoption and migration paths
 - `platform.html` - platform overview
 - `protocols.html` - protocol surface and compatibility story

--- a/ai-gis.html
+++ b/ai-gis.html
@@ -68,6 +68,13 @@
               data-analytics-destination="index.html#contact"
             >Talk to us</a>
             <a class="btn btn-ghost" href="https://github.com/honua-io/geospatial-mcp" target="_blank" rel="noopener noreferrer">MCP spec ↗</a>
+            <a
+              class="btn btn-ghost"
+              href="honua-gis.html"
+              data-analytics-event="cta_click"
+              data-analytics-label="ai_gis_hero_honua_gis"
+              data-analytics-destination="honua-gis.html"
+            >Honua-GIS evals</a>
           </div>
         </div>
 
@@ -181,6 +188,18 @@
             <span class="t">Simple operations</span>
             <span class="b">Terraform, OpenTelemetry, and GitOps.</span>
             <span class="more">Read pillar 05</span>
+          </a>
+          <a class="bed-related-card" href="performance.html">
+            <span class="n">06</span>
+            <span class="t">High performance</span>
+            <span class="b">AOT-compiled engine, benchmarked, cloud-optimized.</span>
+            <span class="more">Read pillar 06</span>
+          </a>
+          <a class="bed-related-card" href="honua-gis.html">
+            <span class="n">GIS</span>
+            <span class="t">Honua-GIS</span>
+            <span class="b">Open-weights GIS model/eval track, status table, and release gates.</span>
+            <span class="more">Read Honua-GIS</span>
           </a>
         </div>
       </section>

--- a/claims.html
+++ b/claims.html
@@ -152,6 +152,12 @@
                 <td class="honua"><span class="evidence-badge amber">Preview partial</span> <span class="evidence-badge gray">External owner</span></td>
                 <td class="honua"><a href="https://github.com/honua-io/honua-qgis-plugin" target="_blank" rel="noopener noreferrer">honua-qgis-plugin</a></td>
               </tr>
+              <tr id="honua-gis-model">
+                <td class="area">Honua-GIS model/eval track</td>
+                <td class="legacy">Say Honua-GIS is an open-weights GIS model/eval track with a published benchmark dataset, eval harness, model-card scaffold, and GGUF/Ollama workflow. Do not claim released fine-tuned weights, quality improvements, an Ollama pull tag, a NIM image/endpoint, or production readiness until honua-gis-llm publishes exact artifacts.</td>
+                <td class="honua"><span class="evidence-badge green">Source-backed</span> <span class="evidence-badge blue">Proof pending</span> <span class="evidence-badge gray">External owner</span></td>
+                <td class="honua"><a href="honua-gis.html">honua-gis.html</a> · <a href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/baselines/README.md" target="_blank" rel="noopener noreferrer">baseline runbooks</a> · <a href="https://github.com/honua-io/honua-gis-llm/issues/21" target="_blank" rel="noopener noreferrer">live baseline gate</a> · <a href="https://github.com/honua-io/honua-gis-llm/issues/19" target="_blank" rel="noopener noreferrer">NIM smoke gate</a></td>
+              </tr>
               <tr id="mobile-field">
                 <td class="area">Mobile · field · offline · MAUI</td>
                 <td class="legacy">Label as Beta or pilot-scoped. Do not present offline sync, conflict handling, or device workflows as Preview-ready.</td>

--- a/docs.html
+++ b/docs.html
@@ -108,6 +108,7 @@ PY</code></pre>
         <li>Read the <a href="cloud-native.html">Cloud-native</a> pillar and grab the <a href="https://github.com/honua-io/honua-terraform" target="_blank" rel="noopener noreferrer">Terraform module</a> when you want a real deployment.</li>
         <li>Read the <a href="operations.html">Simple operations</a> pillar for OpenTelemetry, OIDC, and the GitOps loop.</li>
         <li>Open the <a href="qgis-plugin.html">Honua QGIS Plugin</a> page for the early-preview QGIS assistant install path and local-first privacy boundary.</li>
+        <li>Read <a href="honua-gis.html">Honua-GIS</a> for the open-weights GIS model/eval track, source-backed status table, and pending Ollama/NIM release gates.</li>
         <li>Check the <a href="claims.html">Claims matrix</a> for the wording rules that govern every public number on this site.</li>
       </ul>
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -36,6 +36,7 @@ Supporting/detail pages:
 - `platform.html`: platform overview for users who want the broad architecture.
 - `agentic-gis.html`: AI-agent and MCP detail page.
 - `qgis-plugin.html`: early-preview Honua GIS Assistant QGIS plugin landing page, bounded to source/release/media artifacts owned by `honua-qgis-plugin`.
+- `honua-gis.html`: Honua-GIS open-weights model/eval track, source-backed status table, and pending model-serving release gates.
 - `runtime.html`: gRPC/runtime detail page.
 - `devops.html`: GitOps, observability, and operations detail page.
 - `sdks.html`: SDK detail page.

--- a/honua-gis.html
+++ b/honua-gis.html
@@ -1,0 +1,352 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Honua-GIS | Open-weights GIS model evals</title>
+    <meta name="description" content="Honua-GIS is Honua's open-weights GIS model and evaluation track: benchmark dataset, model-card scaffold, GGUF/Ollama workflow, and pending release gates for weights and NIM." />
+    <meta property="og:title" content="Honua-GIS | Honua" />
+    <meta property="og:description" content="Open-weights GIS model and evaluation track with published benchmark scaffolding and visible release gates." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://honua.io/honua-gis.html" />
+    <meta property="og:image" content="https://honua.io/assets/og-image.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Honua-GIS | Honua" />
+    <meta name="twitter:description" content="Open-weights GIS model and evaluation track with source-backed status." />
+    <meta name="twitter:image" content="https://honua.io/assets/og-image.png" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://www.google-analytics.com https://honua.io; form-action 'self' https://formsubmit.co; upgrade-insecure-requests" />
+    <script defer src="assets/analytics.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+    <link rel="icon" type="image/png" sizes="32x32" href="assets/favicon-32.png" />
+    <link rel="canonical" href="https://honua.io/honua-gis.html" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="bed-nav">
+      <a class="brand" href="index.html" aria-label="Honua home">
+        <img src="assets/honua-logo.svg" alt="" aria-hidden="true" />
+        <span class="wm">Honua</span>
+      </a>
+      <button class="nav-toggle" aria-expanded="false" aria-label="Toggle navigation"><span></span><span></span><span></span></button>
+      <nav class="nav-groups" aria-label="Primary">
+        <a href="interoperability.html">Compatibility</a>
+        <a href="migration.html">Low risk migration</a>
+        <a href="open-core.html">Predictable cost</a>
+        <a href="cloud-native.html">Cloud-native</a>
+        <a href="operations.html">Simple operations</a>
+        <a href="performance.html">Performance</a>
+        <a href="ai-gis.html">AI-ready</a>
+        <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
+        <a
+          class="nav-cta"
+          href="index.html#contact"
+          data-analytics-event="cta_click"
+          data-analytics-label="honua_gis_nav_contact"
+          data-analytics-destination="index.html#contact"
+        >Talk to us</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="bed-hero single">
+        <div class="hex-bg" aria-hidden="true"></div>
+        <div style="position: relative; max-width: 900px;">
+          <span class="eyebrow">// honua-gis · model/eval track</span>
+          <h1 style="max-width: none;">Honua-GIS<br /><span class="teal">open-weights GIS evals.</span></h1>
+          <p class="bed-lede" style="max-width: 720px;">
+            Honua-GIS is the public track for a GIS-focused coding and workflow assistant:
+            a benchmark dataset, deterministic eval harness, model-card scaffold, GGUF/Ollama
+            packaging workflow, and NIM serving gate. The source track is open; released model
+            quality and serving commands stay pending until their artifacts publish.
+          </p>
+          <div class="cta-row">
+            <a
+              class="btn btn-primary"
+              href="https://github.com/honua-io/honua-gis-llm"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-analytics-event="cta_click"
+              data-analytics-label="honua_gis_hero_repo"
+              data-analytics-destination="https://github.com/honua-io/honua-gis-llm"
+            >Source repo ↗</a>
+            <a
+              class="btn btn-ghost"
+              href="#eval-status"
+              data-analytics-event="cta_click"
+              data-analytics-label="honua_gis_hero_eval_status"
+              data-analytics-destination="#eval-status"
+            >Eval status</a>
+            <a
+              class="btn btn-ghost"
+              href="#honua-gis-quickstart"
+              data-analytics-event="cta_click"
+              data-analytics-label="honua_gis_hero_quickstart"
+              data-analytics-destination="#honua-gis-quickstart"
+            >Quickstart gates</a>
+          </div>
+          <p class="footnote">
+            Source snapshot: honua-gis-llm commit 8ddf9331417d28644cb650c3eb67f92193ac337f.
+          </p>
+        </div>
+      </section>
+
+      <section class="bed-pillar-detail" aria-labelledby="status-title">
+        <div class="section-head">
+          <span class="eyebrow">// release status</span>
+          <h2 id="status-title">What is published, and what is not.</h2>
+          <p class="sub">The public page follows the same claims rule as the rest of Honua: shipped source evidence is linked, and missing model artifacts remain visibly pending.</p>
+        </div>
+        <div class="card-grid cols-3">
+          <div class="card">
+            <span class="lbl">Benchmark</span>
+            <span class="tt">50-prompt GIS eval dataset</span>
+            <p class="bd">Published with four task classes, deterministic graders, a report schema, and baseline runbooks. Live baseline reports are not published yet.</p>
+            <div class="foot"><span class="evidence-badge green">Source-backed</span></div>
+          </div>
+          <div class="card amber">
+            <span class="lbl">Model weights</span>
+            <span class="tt">Honua-GIS-32B planned</span>
+            <p class="bd">The model card names Qwen/Qwen2.5-Coder-32B-Instruct as the planned base model. No fine-tuned weights are published by the source repo yet.</p>
+            <div class="foot"><span class="evidence-badge amber">Pending artifact</span></div>
+          </div>
+          <div class="card amber">
+            <span class="lbl">Ollama / GGUF</span>
+            <span class="tt">Workflow published, tag pending</span>
+            <p class="bd">Conversion scripts and Modelfiles exist. The Ollama namespace URL, latest tag, GGUF SHA-256, and live smoke evidence are still null in the state file.</p>
+            <div class="foot"><span class="evidence-badge amber">Pending tag</span></div>
+          </div>
+          <div class="card amber">
+            <span class="lbl">NIM</span>
+            <span class="tt">Wrapper published, live smoke pending</span>
+            <p class="bd">The NIM wrapper and smoke harness are in source. A hosted endpoint, entitlement requirements, and live smoke report are owned by the open NIM evidence ticket.</p>
+            <div class="foot"><span class="evidence-badge blue">External owner</span></div>
+          </div>
+          <div class="card">
+            <span class="lbl">Licenses</span>
+            <span class="tt">Split metadata published</span>
+            <p class="bd">Tooling, benchmark data, base-model, corpus, and distributed artifact license boundaries are tracked separately. Site copy is not a model-weight license grant.</p>
+            <div class="foot"><span class="evidence-badge green">Source-backed</span></div>
+          </div>
+          <div class="card">
+            <span class="lbl">Site claim</span>
+            <span class="tt">Open-weights track, not released quality</span>
+            <p class="bd">This page may claim an open eval/model track. It must not claim production readiness, quality gains, or released serving tags before source artifacts publish them.</p>
+            <div class="foot"><a class="text-link" href="claims.html#honua-gis-model">claims row</a></div>
+          </div>
+        </div>
+      </section>
+
+      <section id="eval-status" class="bed-pillar-detail transparent" aria-labelledby="eval-title">
+        <div class="section-head">
+          <span class="eyebrow">// eval table</span>
+          <h2 id="eval-title">Evaluation evidence currently available.</h2>
+          <p class="sub">No model-quality numbers are restated here because the source baseline reports and fine-tune comparison are still pending live runs.</p>
+        </div>
+        <div class="table-wrap">
+          <table class="bed-data-table" style="min-width: 980px;">
+            <thead>
+              <tr>
+                <th>Artifact</th>
+                <th>Run / commit</th>
+                <th>Task classes</th>
+                <th>Result fields</th>
+                <th>Evidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="area">gis-workflow-eval dataset and harness</td>
+                <td class="legacy">8ddf9331417d28644cb650c3eb67f92193ac337f</td>
+                <td class="honua">query 13, geoprocessing 12, styling 13, raster_ops 12</td>
+                <td class="legacy">50 prompts; deterministic graders; report schema published.</td>
+                <td class="honua"><a href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/benchmarks/gis-workflow-eval/README.md" target="_blank" rel="noopener noreferrer">benchmark README</a></td>
+              </tr>
+              <tr>
+                <td class="area">Baseline runbooks</td>
+                <td class="legacy">8ddf9331417d28644cb650c3eb67f92193ac337f</td>
+                <td class="honua">Qwen 2.5 Coder 32B, GPT-4o, Claude Opus 4.1</td>
+                <td class="legacy">Configs and commands are published; `report.json` files are pending provider credentials and Qwen endpoint access.</td>
+                <td class="honua"><a href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/baselines/README.md" target="_blank" rel="noopener noreferrer">baseline README</a> · <a href="https://github.com/honua-io/honua-gis-llm/issues/21" target="_blank" rel="noopener noreferrer">live baseline gate</a></td>
+              </tr>
+              <tr>
+                <td class="area">Honua-GIS-32B model-card eval table</td>
+                <td class="legacy">Last updated 2026-05-22</td>
+                <td class="honua">overall, query, geoprocessing, styling, raster_ops</td>
+                <td class="legacy">Honua-GIS, Qwen base, GPT-4o, and Claude comparison pass rates are all TBD in source.</td>
+                <td class="honua"><a href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/model-card/eval-table.md" target="_blank" rel="noopener noreferrer">eval table</a></td>
+              </tr>
+              <tr>
+                <td class="area">Ollama / GGUF smoke path</td>
+                <td class="legacy">pending live run</td>
+                <td class="honua">serving smoke only</td>
+                <td class="legacy">Tokens/sec, p50 latency, GGUF SHA-256, and namespace tag are null in the state file.</td>
+                <td class="honua"><a href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/docs/distribution/ollama-upstream-state.json" target="_blank" rel="noopener noreferrer">Ollama state</a></td>
+              </tr>
+              <tr>
+                <td class="area">NIM smoke path</td>
+                <td class="legacy">wrapper merged; live smoke pending honua-gis-llm#19</td>
+                <td class="honua">serving smoke only</td>
+                <td class="legacy">NIM wrapper and dry-run harness are published; endpoint, entitlement, throughput, and latency live evidence are not published.</td>
+                <td class="honua"><a href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/benchmarks/nim-smoke/README.md" target="_blank" rel="noopener noreferrer">NIM smoke README</a> · <a href="https://github.com/honua-io/honua-gis-llm/issues/19" target="_blank" rel="noopener noreferrer">live smoke gate</a></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="footnote">NIM or GGUF smoke evidence proves serving plumbing only; it is not a substitute for gis-workflow-eval model-quality results.</p>
+      </section>
+
+      <section id="honua-gis-quickstart" class="bed-pillar-detail" aria-labelledby="quickstart-title">
+        <div class="section-head">
+          <span class="eyebrow">// evaluator quickstart</span>
+          <h2 id="quickstart-title">Run only what the source artifacts support.</h2>
+          <p class="sub">The source repo publishes an eval harness and local GGUF/Ollama workflow. It does not yet publish a pullable Ollama tag, Hugging Face weight repo, or NIM image.</p>
+        </div>
+        <div class="row-2">
+          <div class="code-block">
+            <div class="code-head">Ollama / GGUF source workflow</div>
+            <div class="code-body">
+              <div class="line"><span class="com"># Requires a generated artifacts/gguf/honua-gis.Q4_K_M.gguf.</span></div>
+              <div class="line"><span class="kw">python</span> scripts/lint_modelfile.py ollama/Modelfile.q4_k_m</div>
+              <div class="line"><span class="kw">ollama</span> create honua-gis -f ollama/Modelfile.q4_k_m</div>
+              <div class="line"><span class="kw">ollama</span> run honua-gis <span class="str">"Write a PostGIS query for parcels within 250 meters of fire stations."</span></div>
+              <div class="line">&nbsp;</div>
+              <div class="line"><span class="com"># Do not use ollama pull honua/honua-gis until the state file records a tag and SHA.</span></div>
+            </div>
+          </div>
+          <div class="code-block">
+            <div class="code-head">NIM release gate</div>
+            <div class="code-body">
+              <div class="line"><span class="com"># No public NIM quickstart is available yet.</span></div>
+              <div class="line"><span class="com"># honua-gis-llm#19 must publish:</span></div>
+              <div class="line">- NIM endpoint or image/SKU</div>
+              <div class="line">- entitlement and API-key requirements</div>
+              <div class="line">- exact model id for OpenAI-compatible calls</div>
+              <div class="line">- hosted smoke report with throughput and latency</div>
+              <div class="line">&nbsp;</div>
+              <div class="line"><span class="com"># Until then, no NIM curl command on this page is source-backed.</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="cta-row">
+          <a
+            class="btn btn-primary"
+            href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/docs/training/gguf-and-ollama.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-analytics-event="cta_click"
+            data-analytics-label="honua_gis_ollama_workflow"
+            data-analytics-destination="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/docs/training/gguf-and-ollama.md"
+          >Ollama workflow ↗</a>
+          <a
+            class="btn btn-ghost"
+            href="https://github.com/honua-io/honua-gis-llm/issues/19"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-analytics-event="cta_click"
+            data-analytics-label="honua_gis_nim_gate"
+            data-analytics-destination="https://github.com/honua-io/honua-gis-llm/issues/19"
+          >NIM gate ↗</a>
+        </div>
+      </section>
+
+      <section class="bed-pillar-detail transparent" aria-labelledby="artifacts-title">
+        <div class="section-head">
+          <span class="eyebrow">// model cards and licenses</span>
+          <h2 id="artifacts-title">Artifact links and caveats.</h2>
+        </div>
+        <div class="card-grid cols-3">
+          <a class="card" href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/model-card/README.md" target="_blank" rel="noopener noreferrer">
+            <span class="lbl">Model card</span>
+            <span class="tt">Honua-GIS-32B scaffold</span>
+            <span class="bd">Names intended use, out-of-scope use, risks, and TBD metrics before weights publish.</span>
+            <span class="foot">model-card/README.md ↗</span>
+          </a>
+          <a class="card" href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/model-card/licenses.md" target="_blank" rel="noopener noreferrer">
+            <span class="lbl">Licenses</span>
+            <span class="tt">Tooling, data, base weights</span>
+            <span class="bd">Apache-2.0 tooling, CC BY 4.0 benchmark data, base-model terms, corpus metadata, and distributed-artifact license posture are separated.</span>
+            <span class="foot">model-card/licenses.md ↗</span>
+          </a>
+          <a class="card" href="https://github.com/honua-io/honua-gis-llm/blob/8ddf9331417d28644cb650c3eb67f92193ac337f/corpus/v0.1/index.json" target="_blank" rel="noopener noreferrer">
+            <span class="lbl">Corpus provenance</span>
+            <span class="tt">Training corpus index</span>
+            <span class="bd">The corpus index is the source for per-record provenance. Do not infer redistributed model-weight rights from site copy.</span>
+            <span class="foot">corpus/v0.1/index.json ↗</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="bed-pillar-detail" aria-labelledby="limits-title">
+        <div class="section-head">
+          <span class="eyebrow">// limitations</span>
+          <h2 id="limits-title">Use this page as a status surface, not a release note.</h2>
+        </div>
+        <div class="card-grid cols-2">
+          <div class="card amber">
+            <span class="lbl">No released quality claim</span>
+            <p class="bd">Until gis-workflow-eval reports publish exact pass rates, Honua-GIS should not be described as outperforming any base model or closed model.</p>
+          </div>
+          <div class="card amber">
+            <span class="lbl">No production readiness claim</span>
+            <p class="bd">The model-card scaffold says outputs require human review and must not be used for emergency, legal, surveying, permitting, environmental compliance, or safety decisions.</p>
+          </div>
+          <div class="card amber">
+            <span class="lbl">No public pull command yet</span>
+            <p class="bd">The unprefixed and namespaced Ollama pull commands must wait for the source state file to record a namespace URL, tag, and GGUF SHA-256.</p>
+          </div>
+          <div class="card amber">
+            <span class="lbl">NIM requires source-owned evidence</span>
+            <p class="bd">The site will add exact NIM commands only after the source repo publishes entitlement requirements, endpoint or image/SKU, and smoke evidence.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="bed-cta-band">
+        <span class="eyebrow">// next</span>
+        <h2>Evaluate the track.<br /><span class="teal">Keep the claims sourced.</span></h2>
+        <div class="row">
+          <a
+            class="btn btn-primary"
+            href="https://github.com/honua-io/honua-gis-llm"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-analytics-event="cta_click"
+            data-analytics-label="honua_gis_cta_repo"
+            data-analytics-destination="https://github.com/honua-io/honua-gis-llm"
+          >Source repo ↗</a>
+          <a
+            class="btn btn-ghost"
+            href="claims.html#honua-gis-model"
+            data-analytics-event="cta_click"
+            data-analytics-label="honua_gis_cta_claims"
+            data-analytics-destination="claims.html#honua-gis-model"
+          >Claims row</a>
+        </div>
+      </section>
+    </main>
+
+    <footer id="contact" class="bed-footer">
+      <div class="footer-row">
+        <div class="left">
+          <img src="assets/honua-logo.svg" alt="" aria-hidden="true" />
+          <span class="mono">honua · /ˈhoʊnuə/ · earth</span>
+        </div>
+        <div class="links mono">
+          <a href="https://github.com/honua-io" target="_blank" rel="noopener noreferrer">GITHUB</a>
+          <a href="docs.html">DOCS</a>
+          <a href="claims.html">CLAIMS</a>
+          <a href="security.html">SECURITY</a>
+          <a href="privacy.html">PRIVACY</a>
+          <a href="terms.html">TERMS</a>
+          <a href="mailto:info@honua.io">INFO@HONUA.IO</a>
+        </div>
+      </div>
+      <div class="footer-legal mono">
+        Esri®, ArcGIS®, ArcGIS Server®, ArcGIS Pro®, ArcGIS Runtime®, ArcGIS Online® and the ArcGIS JavaScript, .NET, Python, and Maps SDKs are trademarks of Environmental Systems Research Institute, Inc. Honua is not affiliated with, sponsored by, or endorsed by Esri.
+      </div>
+    </footer>
+    <script defer src="assets/nav.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- adds `honua-gis.html` as a claims-safe Honua-GIS model/eval status surface
- links the AI-ready page, docs hub, feature index, and claims matrix to the new page
- points evidence at current `honua-gis-llm` commit `8ddf9331417d28644cb650c3eb67f92193ac337f` and the live-evidence child gates `honua-gis-llm#21` and `honua-gis-llm#19`

Refs #25. This intentionally does not close #25 because the final announcement still requires live baseline reports, fine-tune deltas, and NIM smoke evidence.

## Validation
- `./scripts/validate-lead-capture.sh`
- `./scripts/validate-security-headers.sh`
- `./scripts/validate-workflow-pinning.sh`
- `./scripts/build-dist.sh`
- `git diff --check`