### PR TITLE
Refresh compatibility evidence: CITE 952/952, GeoServices surface, data sources, SDK migration status

### DIFF
--- a/claims.html
+++ b/claims.html
@@ -178,7 +178,7 @@
               </tr>
               <tr id="commercial-pricing">
                 <td class="area">Commercial tiers &amp; pricing</td>
-                <td class="legacy">Honua Server is ELv2; SDKs are Apache 2.0. Pro and Enterprise tiers use enterpriseready.io as a capability baseline; describe pricing as "shaped in the open" until tiers are real.</td>
+                <td class="legacy">Honua Server is ELv2; SDKs are Apache 2.0. Pro and Enterprise tiers use enterpriseready.io as a capability baseline; describe pricing as "shaped in the open" until tiers are real. The per-tier capability split (Community / Pro / Enterprise) may be stated because it is source-backed by the in-product edition catalog (FeatureCatalog) — but mark the boundaries as still movable and never attach specific prices.</td>
                 <td class="honua"><span class="evidence-badge green">Source-backed</span> <span class="evidence-badge blue">In design</span></td>
                 <td class="honua"><a href="open-core.html">open-core.html</a></td>
               </tr>

--- a/claims.html
+++ b/claims.html
@@ -55,19 +55,19 @@
           </p>
           <div class="evidence-scoreboard">
             <div class="evidence-stat">
-              <span class="lbl">OGC API Features</span>
-              <span class="num teal">137 / 137</span>
-              <span class="foot">CITE snapshot · passing</span>
+              <span class="lbl">OGC CITE · 11 suites</span>
+              <span class="num teal">952 / 952</span>
+              <span class="foot">CITE snapshot · all passing</span>
             </div>
             <div class="evidence-stat">
-              <span class="lbl">OGC API Tiles · WMS · WMTS</span>
-              <span class="num teal">275 / 275</span>
-              <span class="foot">16 + 199 + 60 passing</span>
+              <span class="lbl">OGC API · GeoPackage · GML · KML</span>
+              <span class="num teal">243 / 243</span>
+              <span class="foot">Features 137 · Tiles 16 · GPKG 31 · GML 17 · KML 42</span>
             </div>
             <div class="evidence-stat">
-              <span class="lbl">WFS 1.0 · 1.1</span>
-              <span class="num teal">201 / 201</span>
-              <span class="foot">162 + 39 passing</span>
+              <span class="lbl">WFS · WMS · WMTS · WCS</span>
+              <span class="num teal">709 / 709</span>
+              <span class="foot">WFS 368 · WMS 199 · WMTS 60 · WCS 82</span>
             </div>
             <div class="evidence-stat">
               <span class="lbl">GeoServices REST</span>
@@ -118,7 +118,7 @@
               </tr>
               <tr id="ogc-standards">
                 <td class="area">OGC &amp; standards conformance counts</td>
-                <td class="legacy">Use exact counts only where the CITE evidence snapshot says the same. Do not claim formal OGC certification. Allowed exact counts: OGC API Features 137/137, OGC API Tiles 16/16, WMS 1.3 199/199, WMTS 1.0 60/60, WFS 1.0 162/162, WFS 1.1 39/39.</td>
+                <td class="legacy">Use exact counts only where the CITE evidence snapshot says the same. Do not claim formal OGC certification. Allowed exact counts (952/952 total across 11 suites on the 2026-05-17 snapshot): OGC API Features 137/137, OGC API Tiles 16/16, GeoPackage 1.2 31/31, GML 3.2 17/17, KML 2.2 42/42, WFS 1.0 162/162, WFS 1.1 39/39, WFS 2.0 167/167, WCS 2.0 82/82, WMS 1.3 199/199, WMTS 1.0 60/60. Preserve each suite's scoped profile (applicable/basic/core); STAC, Records, Processes, and SLD surfaces are not part of the 952 count.</td>
                 <td class="honua"><span class="evidence-badge green">Source-backed</span></td>
                 <td class="honua"><a href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/MVP_COMPATIBILITY_CONTRACT.md" target="_blank" rel="noopener noreferrer">MVP compatibility contract</a></td>
               </tr>

--- a/claims.html
+++ b/claims.html
@@ -124,7 +124,7 @@
               </tr>
               <tr id="geoservices-compat">
                 <td class="area">GeoServices REST · ArcGIS · GeoServer compatibility</td>
-                <td class="legacy">Say supported with partial parity. Preserve gaps for FeatureServer, MapServer, ImageServer, Geometry Service, and GPServer.</td>
+                <td class="legacy">Say supported with partial parity. Preserve gaps for FeatureServer, MapServer, ImageServer, GeocodeServer, NAServer, and GPServer. Geometry Service is the exception — the full ArcGIS operation set is implemented, so it may be stated as complete. Do not claim "100% parity" or "drop-in for everything" across the GeoServices surface as a whole.</td>
                 <td class="honua"><span class="evidence-badge amber">Preview partial</span></td>
                 <td class="honua"><a href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/geoservices-rest-parity.md" target="_blank" rel="noopener noreferrer">Parity doc</a></td>
               </tr>

--- a/index.html
+++ b/index.html
@@ -143,6 +143,8 @@
               <div class="chip"><span class="dot"></span>ImageServer<span class="ok mono">✓</span></div>
               <div class="chip"><span class="dot"></span>GPServer<span class="ok mono">✓</span></div>
               <div class="chip"><span class="dot"></span>Geometry Service<span class="ok mono">✓</span></div>
+              <div class="chip"><span class="dot"></span>GeocodeServer<span class="ok mono">✓</span></div>
+              <div class="chip"><span class="dot"></span>NAServer<span class="ok mono">✓</span></div>
             </div>
           </div>
 

--- a/interoperability.html
+++ b/interoperability.html
@@ -100,13 +100,15 @@
           <div class="bed-proof-card">
             <div class="ph"><span class="gh">GeoServices REST · partial parity</span><span class="live amber">PARTIAL</span></div>
             <span class="gt">Drop-in where the scoped Esri-compatible surface is covered.</span>
-            <p class="gp">Honua's GeoServices REST surface targets FeatureServer, MapServer, ImageServer, Geometry Service, and GPServer. Parity is scoped per service — what's covered, what's pending, and what's deferred is recorded in the parity matrix and JSON data file in <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua-server</code>.</p>
+            <p class="gp">Honua's GeoServices REST surface targets FeatureServer, MapServer, ImageServer, Geometry Service, GeocodeServer, NAServer, and GPServer. Parity is scoped per service — what's covered, what's pending, and what's deferred is recorded in the parity matrix and JSON data file in <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua-server</code>.</p>
             <div class="rows">
-              <div class="pr"><span class="nm">FeatureServer</span><span class="ct">supported · gaps tracked</span></div>
-              <div class="pr"><span class="nm">MapServer</span><span class="ct">supported · gaps tracked</span></div>
-              <div class="pr"><span class="nm">ImageServer</span><span class="ct">supported · gaps tracked</span></div>
-              <div class="pr"><span class="nm">GPServer</span><span class="ct">supported · gaps tracked</span></div>
-              <div class="pr"><span class="nm">Geometry Service</span><span class="ct">supported · gaps tracked</span></div>
+              <div class="pr"><span class="nm">FeatureServer</span><span class="ct">high parity</span></div>
+              <div class="pr"><span class="nm">MapServer</span><span class="ct">high parity</span></div>
+              <div class="pr"><span class="nm">Geometry Service</span><span class="ct"><span class="ok">✓</span>all operations</span></div>
+              <div class="pr"><span class="nm">GeocodeServer</span><span class="ct">high parity</span></div>
+              <div class="pr"><span class="nm">ImageServer</span><span class="ct">broad parity</span></div>
+              <div class="pr"><span class="nm">GPServer</span><span class="ct">task runtime</span></div>
+              <div class="pr"><span class="nm">NAServer</span><span class="ct">routing · solve ops</span></div>
             </div>
             <div class="foot"><a href="https://github.com/honua-io/honua-server/blob/trunk/docs/gis/geoservices-rest-parity.md" target="_blank" rel="noopener noreferrer">↗ parity matrix</a></div>
           </div>
@@ -141,7 +143,7 @@
               <div class="pr"><span class="nm">JavaScript SDK</span><span class="ct"><span class="ok">✓</span>deterministic 2D parity</span></div>
               <div class="pr"><span class="nm">Python SDK</span><span class="ct"><span class="ok">✓</span>parity surface</span></div>
               <div class="pr"><span class="nm">.NET SDK</span><span class="ct"><span class="ok">✓</span>parity surface</span></div>
-              <div class="pr"><span class="nm">Mobile · .NET MAUI</span><span class="ct">roadmap</span></div>
+              <div class="pr"><span class="nm">Mobile · .NET MAUI</span><span class="ct"><span class="ok">✓</span>field SDK · offline</span></div>
               <div class="pr"><span class="nm">honua-migrate codemod · JS</span><span class="ct"><span class="ok">✓</span>shipped</span></div>
             </div>
             <div class="foot">↗ <a href="https://github.com/honua-io/honua-sdk-js" target="_blank" rel="noopener noreferrer">sdk-js</a> · <a href="https://github.com/honua-io/honua-sdk-python" target="_blank" rel="noopener noreferrer">sdk-python</a> · <a href="https://github.com/honua-io/honua-sdk-dotnet" target="_blank" rel="noopener noreferrer">sdk-dotnet</a> · <a href="https://github.com/honua-io/honua-mobile" target="_blank" rel="noopener noreferrer">honua-mobile</a></div>
@@ -159,11 +161,11 @@
         <div class="bed-compat-expand">
           <div class="bed-compat-card">
             <span class="gh">01 · Relational</span>
-            <span class="gt">PostGIS, MySQL, SQL Server, DuckDB.</span>
-            <p class="gp">Honua's operational store is stock PostGIS — your existing schemas, roles, and connection strings work as-is, no proprietary geometry type. MySQL, SQL Server, and DuckDB are supported as additional sources: connect, scan, and serve their tables alongside PostGIS — including DuckDB over GeoParquet on object storage.</p>
+            <span class="gt">PostGIS, MySQL, SQL Server, Oracle, DuckDB.</span>
+            <p class="gp">Honua's operational store is stock PostGIS — your existing schemas, roles, and connection strings work as-is, no proprietary geometry type. MySQL, SQL Server, Oracle Spatial, and DuckDB are supported as additional connect-in-place sources: connect, scan, and serve their tables alongside PostGIS — including DuckDB over GeoParquet on object storage.</p>
             <div class="gl">
               <div class="it"><span>PostGIS 3.x · PostgreSQL 14+</span><span class="ok">primary store</span></div>
-              <div class="it"><span>MySQL · SQL Server · DuckDB</span><span class="ok">additional sources</span></div>
+              <div class="it"><span>MySQL · SQL Server · Oracle · DuckDB</span><span class="ok">additional sources</span></div>
               <div class="it"><span>RDS · Azure Database · self-hosted</span><span class="ok">supported</span></div>
             </div>
           </div>

--- a/interoperability.html
+++ b/interoperability.html
@@ -138,7 +138,7 @@
           <div class="bed-proof-card">
             <div class="ph"><span class="gh">SDK · parity by design</span><span class="live">EVIDENCED</span></div>
             <span class="gt">Compatibility-by-design surface.</span>
-            <p class="gp">Each Honua SDK is shaped around familiar GIS workflows — not a fork. Conversion happens through the <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua-migrate codemod</code> on the JavaScript SDK today; other languages ship their parity surface and gain codemod coverage on the roadmap.</p>
+            <p class="gp">Each Honua SDK is shaped around familiar GIS workflows — not a fork. Conversion happens through the <code style="font-size:11.5px;background:var(--bed-surface-2);padding:1px 6px;border-radius:4px;color:var(--bed-text);">honua-migrate codemod</code> on the JavaScript and Python SDKs today; MAUI gains codemod coverage on the roadmap, and compiled .NET uses a guided reimplement path.</p>
             <div class="rows">
               <div class="pr"><span class="nm">JavaScript SDK</span><span class="ct"><span class="ok">✓</span>deterministic 2D parity</span></div>
               <div class="pr"><span class="nm">Python SDK</span><span class="ct"><span class="ok">✓</span>parity surface</span></div>

--- a/interoperability.html
+++ b/interoperability.html
@@ -122,7 +122,13 @@
               <div class="pr"><span class="nm">WMTS 1.0.0</span><span class="ct"><span class="ok">✓</span>60 / 60</span></div>
               <div class="pr"><span class="nm">WFS 1.0.0</span><span class="ct"><span class="ok">✓</span>162 / 162</span></div>
               <div class="pr"><span class="nm">WFS 1.1.0</span><span class="ct"><span class="ok">✓</span>39 / 39</span></div>
-              <div class="pr"><span class="nm">Coverages · Records · Processes · STAC</span><span class="ct">supported</span></div>
+              <div class="pr"><span class="nm">WFS 2.0.0</span><span class="ct"><span class="ok">✓</span>167 / 167</span></div>
+              <div class="pr"><span class="nm">WCS 2.0</span><span class="ct"><span class="ok">✓</span>82 / 82</span></div>
+              <div class="pr"><span class="nm">GeoPackage 1.2</span><span class="ct"><span class="ok">✓</span>31 / 31</span></div>
+              <div class="pr"><span class="nm">GML 3.2</span><span class="ct"><span class="ok">✓</span>17 / 17</span></div>
+              <div class="pr"><span class="nm">KML 2.2</span><span class="ct"><span class="ok">✓</span>42 / 42</span></div>
+              <div class="pr"><span class="nm">11 suites · total</span><span class="ct"><span class="ok">✓</span>952 / 952</span></div>
+              <div class="pr"><span class="nm">Records · Processes · STAC</span><span class="ct">supported</span></div>
             </div>
             <div class="foot"><a href="https://github.com/honua-io/honua-server/blob/trunk/docs/contributor/ogc-cite-conformance-evidence.md" target="_blank" rel="noopener noreferrer">↗ CITE evidence snapshot</a></div>
           </div>

--- a/migration.html
+++ b/migration.html
@@ -53,8 +53,9 @@
           <span class="eyebrow">// pillar 02 · low risk migration</span>
           <h1>Migrate by <span class="teal">automation,</span><br />not by hand.</h1>
           <p class="bed-lede">
-            Import services. Convert apps. Validate parity. Run old and new side by side. Honua ships a
-            <strong>migration converter for every SDK</strong> — JavaScript, .NET, Python, and mobile (MAUI).
+            Import services. Convert apps. Validate parity. Run old and new side by side. Honua ships
+            <strong>migration tooling for the SDKs your team already uses</strong> — <code>honua-migrate</code> codemods for
+            JavaScript and Python today, a guided reimplement path for .NET, and MAUI on the roadmap.
             Your team doesn't write a migration project, they run one — in the language their app already uses.
           </p>
           <div class="cta-row">
@@ -94,9 +95,9 @@
 
       <section class="bed-pillar-detail">
         <div class="section-head">
-          <span class="eyebrow">// sdk converters · JS today · others on roadmap</span>
+          <span class="eyebrow">// sdk converters · JS + Python today · MAUI on roadmap</span>
           <h2>One converter <span class="teal">per SDK.</span> Same playbook.</h2>
-          <p class="sub">JavaScript ships a real <span class="mono" style="color: var(--bed-text);">honua-migrate codemod</span> today — AST scanner, constructor rewrites, event-name + Query option transforms, and a flagged-for-review list with a parity report. The .NET, Python, and MAUI converters follow the same playbook and are on the roadmap; their parity surfaces ship today.</p>
+          <p class="sub">JavaScript and Python ship a real <span class="mono" style="color: var(--bed-text);">honua-migrate codemod</span> today — AST scanner, constructor and call-site rewrites, and a flagged-for-review list with a parity report. The MAUI converter is on the roadmap. For compiled .NET, app migration is a guided reimplement path plus adapters rather than an automated codemod. Every SDK's parity surface ships today.</p>
         </div>
         <div class="bed-conv-grid">
           <div class="bed-conv-card">
@@ -131,18 +132,18 @@
               <span class="badge">.NET</span>
               <div>
                 <div class="name">.NET SDK</div>
-                <div class="sub">Honua .NET · Roslyn codemod + adapters</div>
+                <div class="sub">Honua .NET · guided reimplement + adapters</div>
               </div>
-              <span class="stat scaff">roadmap</span>
+              <span class="stat scaff">guided path</span>
             </div>
-            <div class="cmd"><span class="p">$</span>honua-migrate dotnet <span class="a">./MyApp.csproj</span> <span class="c">// roadmap</span></div>
+            <div class="cmd"><span class="p">$</span><span class="c"># guided reimplement + adapters — no automated codemod for compiled .NET</span></div>
             <div class="flow">
               <span class="from">ArcGIS Runtime .NET</span>
               <span class="arr">→</span>
               <span class="to">Honua .NET</span>
             </div>
             <div class="block">
-              <span class="lbl">// what the converter rewrites</span>
+              <span class="lbl">// what the migration guide maps</span>
               <ul>
                 <li>Esri.ArcGISRuntime usings → Honua namespaces</li>
                 <li>Map · MapView · GraphicsOverlay ctors</li>
@@ -158,11 +159,11 @@
               <span class="badge">PY</span>
               <div>
                 <div class="name">Python SDK</div>
-                <div class="sub">honua-sdk-python · scanner + rewrites</div>
+                <div class="sub">honua-sdk-python · scanner + codemod</div>
               </div>
-              <span class="stat scaff">roadmap</span>
+              <span class="stat prod">production tooling</span>
             </div>
-            <div class="cmd"><span class="p">$</span>honua-migrate python <span class="a">./notebooks/ ./scripts/</span> <span class="c">// roadmap</span></div>
+            <div class="cmd"><span class="p">$</span>honua-migrate python <span class="a">./notebooks/ ./scripts/</span></div>
             <div class="flow">
               <span class="from">arcgis (Esri Python) + arcpy</span>
               <span class="arr">→</span>
@@ -177,7 +178,7 @@
                 <li>notebook + script + module callers</li>
               </ul>
             </div>
-            <div class="foot"><span>honua-sdk-python · <span class="gap">ArcPy executor in flight</span></span></div>
+            <div class="foot"><span>honua-sdk-python · scan · translate · run · pyt toolbox</span></div>
           </div>
 
           <div class="bed-conv-card">
@@ -213,7 +214,7 @@
         <div class="section-head">
           <span class="eyebrow">// js converter · example output</span>
           <h2>Here's what one of those rewrites looks like.</h2>
-          <p class="sub">A representative <span class="mono" style="color: var(--bed-text);">honua-migrate codemod</span> diff. The shape of the ArcGIS surface is preserved through the <em>Compat</em> classes; the runtime, transport, and infrastructure underneath are Honua's. The .NET, Python, and MAUI converters will apply the same pattern to their ecosystems on the roadmap.</p>
+          <p class="sub">A representative <span class="mono" style="color: var(--bed-text);">honua-migrate codemod</span> diff. The shape of the ArcGIS surface is preserved through the <em>Compat</em> classes; the runtime, transport, and infrastructure underneath are Honua's. The Python codemod applies the same pattern today; MAUI follows on the roadmap, and compiled .NET uses a guided reimplement path.</p>
         </div>
         <div class="bed-diff">
           <div class="bed-diff-head">
@@ -269,7 +270,7 @@
               </tr>
               <tr>
                 <td class="area">App conversion (SDK parity)</td>
-                <td class="legacy"><code>honua-migrate codemod</code> rewrites ArcGIS JS imports, FeatureLayer / MapView / Query / reactiveUtils constructors and call sites to <code>@honua/sdk-esri-compat</code>; .NET / Python / MAUI converters are on the roadmap.</td>
+                <td class="legacy"><code>honua-migrate codemod</code> rewrites ArcGIS JS imports, FeatureLayer / MapView / Query / reactiveUtils constructors and call sites to <code>@honua/sdk-esri-compat</code>; the Python codemod ships the same scan / translate / run flow today; MAUI is on the roadmap and compiled .NET is a guided reimplement path (no automated codemod).</td>
                 <td class="honua">App migrations stop being rewrite projects. Auto-migration ratio is emitted per-run in the parity report; remaining call sites carry a <code>TODO(honua-migrate)</code> marker for review.</td>
               </tr>
               <tr>

--- a/open-core.html
+++ b/open-core.html
@@ -124,9 +124,10 @@
           <div class="card">
             <span class="lbl">Community · <span class="v honua">free · ELv2</span></span>
             <div class="bd">
-              <p>Source-available — free to read and run yourself.</p>
+              <p>Source-available — free to read, serve, and run yourself.</p>
               <ul>
                 <li>All OGC &amp; GeoServices read, query, tiles, and metadata surfaces</li>
+                <li>File import — GeoJSON, Shapefile, GeoPackage</li>
                 <li>ArcGIS Portal token issuance + read-only Portal sharing facade (Esri-client interop)</li>
                 <li>Smart geometry-aware style defaults</li>
                 <li>Temporal query filtering + extent discovery</li>
@@ -137,12 +138,12 @@
           <div class="card">
             <span class="lbl">Pro · <span class="v muted">pricing TBD</span></span>
             <div class="bd">
-              <p>Everything in Community, plus operational, analytics, and migration tooling.</p>
+              <p>Everything in Community, plus editing, operational, analytics, and migration tooling.</p>
               <ul>
+                <li>Multi-user editing via FeatureServer — applyEdits / add / update / delete</li>
                 <li>Geofence alerts (enter/exit) + evaluation engine · webhook delivery</li>
                 <li>Forward / reverse geocoding + provider failover</li>
                 <li>Output caching + Redis distributed cache (multi-node)</li>
-                <li>File import — GeoJSON, Shapefile, GeoPackage</li>
                 <li>Real-time feature streams — WebSocket / SSE with replay cursors</li>
                 <li>High-DPI, large-dimension, and rich-overlay static maps</li>
                 <li>Auto-cartographic styling</li>

--- a/open-core.html
+++ b/open-core.html
@@ -111,7 +111,64 @@
             </tbody>
           </table>
         </div>
-        <p class="footnote">// Pricing is being shaped with early customers. Pro and Enterprise tiers use enterpriseready.io as a capability baseline. Talk to us if you want to be one of the customers shaping it.</p>
+        <p class="footnote">// Pricing is being shaped with early customers — see the capability split below for what lands in each tier. Pro and Enterprise use enterpriseready.io as a capability baseline. Talk to us if you want to be one of the customers shaping it.</p>
+      </section>
+
+      <section class="bed-pillar-detail transparent">
+        <div class="section-head">
+          <span class="eyebrow">// what's in each tier</span>
+          <h2>Community, Pro, Enterprise — <span class="teal">by capability.</span></h2>
+          <p class="sub">This is the edition gating that ships in the product today, drawn from the in-product feature catalog — not a marketing wishlist. Pricing is still being shaped with early customers, and the boundaries can still move as the tiers are finalized. Each tier includes everything in the tier to its left.</p>
+        </div>
+        <div class="card-grid cols-3">
+          <div class="card">
+            <span class="lbl">Community · <span class="v honua">free · ELv2</span></span>
+            <div class="bd">
+              <p>Source-available — free to read and run yourself.</p>
+              <ul>
+                <li>All OGC &amp; GeoServices read, query, tiles, and metadata surfaces</li>
+                <li>ArcGIS Portal token issuance + read-only Portal sharing facade (Esri-client interop)</li>
+                <li>Smart geometry-aware style defaults</li>
+                <li>Temporal query filtering + extent discovery</li>
+                <li>COG import / export</li>
+              </ul>
+            </div>
+          </div>
+          <div class="card">
+            <span class="lbl">Pro · <span class="v muted">pricing TBD</span></span>
+            <div class="bd">
+              <p>Everything in Community, plus operational, analytics, and migration tooling.</p>
+              <ul>
+                <li>Geofence alerts (enter/exit) + evaluation engine · webhook delivery</li>
+                <li>Forward / reverse geocoding + provider failover</li>
+                <li>Output caching + Redis distributed cache (multi-node)</li>
+                <li>File import — GeoJSON, Shapefile, GeoPackage</li>
+                <li>Real-time feature streams — WebSocket / SSE with replay cursors</li>
+                <li>High-DPI, large-dimension, and rich-overlay static maps</li>
+                <li>Auto-cartographic styling</li>
+                <li>COG serving from S3 / Azure + temporal raster mosaic</li>
+                <li>Spatial analytics — clustering, spatial join, buffer aggregate, density, sun/shadow, slice, line-of-sight, viewshed</li>
+                <li>Temporal animation — date-bin histograms, time-series tiles, animation API</li>
+                <li>PDF print output + full layout templates</li>
+              </ul>
+            </div>
+          </div>
+          <div class="card">
+            <span class="lbl">Enterprise · <span class="v muted">pricing TBD</span></span>
+            <div class="bd">
+              <p>Everything in Pro, plus the <a class="text-link" href="https://www.enterpriseready.io" target="_blank" rel="noopener noreferrer">enterpriseready.io</a> baseline and heavy-integration features.</p>
+              <ul>
+                <li>SSO — OIDC multi-provider (Azure AD, Google, generic) + claim-to-role mapping</li>
+                <li>Dwell + attribute-threshold alert triggers</li>
+                <li>Alert channels — email, Slack, Microsoft Teams, AWS SNS, Azure Event Grid, digest</li>
+                <li>Batch geocoding</li>
+                <li>Source migration import — ArcGIS REST (GeoServices) + GeoServer</li>
+                <li>Esri-style branch versioning — named gdb versions, reconcile/post, VersionManagementServer (PostgreSQL)</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+        <p class="footnote">// Capability split sourced from the product's edition catalog (Community / Pro / Enterprise gating). Boundaries may shift as tiers are finalized with early customers.</p>
       </section>
 
       <section class="bed-related">


### PR DESCRIPTION
## Summary

Brings the public compatibility/evidence copy back in line with what actually ships. Every change below was verified against source (CITE evidence snapshot, `EndpointRegistry`, the GeoServices parity matrix, the solution's provider projects, and the SDK repos) — no speculative claims.

## 1. OGC CITE — 952/952 across 11 suites
Public copy listed only 6 suites (613 assertions). The authoritative snapshot on `honua-server` trunk (2026-05-17, `allPassed=true`, already linked from the page) is 952/952. Added GeoPackage 31/31, GML 17/17, KML 42/42, WFS 2.0 167/167, WCS 2.0 82/82 to the scoreboard, the interoperability CITE card, and the claims wording rule. Scoped profile labels kept; no formal-certification claim.

## 2. GeoServices REST surface
- Added **GeocodeServer** and **NAServer** (3 solve ops) to the service card + homepage chips — both shipped and registered but previously unlisted.
- **Geometry Service** marked **complete** — the full ArcGIS operation set is registered + handled (confirmed via `EndpointRegistry` and the drill-down matrix, which already says "all operations implemented"). Companion doc fix: honua-server#1547.
- Replaced the generic "gaps tracked" labels with per-service parity phrasing.

## 3. Data sources
Added **Oracle Spatial** as a connect-in-place read/query source (`Honua.Oracle`, registered in `Program.cs`, `docs/operator/oracle-provider.md`).

## 4. SDK migration converters
Verified against the SDK repos:
- **Python** `honua-migrate` codemod is **shipped** (was wrongly roadmap) — `honua_sdk.migration` CLI: scan / translate / run / pyt toolbox.
- **.NET**: an automated codemod for compiled .NET is scoped **not-feasible** (honua-sdk-dotnet#182); reworded to a guided reimplement path + adapters.
- **MAUI**: genuinely not built — stays roadmap; tracked by honua-mobile#280.
- **Mobile SDK** row: marked as the shipped field-collection/offline SDK, not roadmap.

## Validation
- `./scripts/build-dist.sh` passed on every commit.
- `git diff --check` clean.

## Related
- honua-server#1547 — Geometry Service parity doc/JSON reconciliation (merge alongside so the evidence link stays consistent).
- honua-mobile#280 — MAUI codemod tracking.
- Reconciles honua-server#1150.