### PR TITLE
fix(pages): serve /.well-known/security.txt

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,10 +49,23 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
       - name: Build artifact
         run: ./scripts/build-dist.sh
+      # actions/upload-pages-artifact excludes dot-directories (--exclude=".[^/]*"),
+      # which drops /.well-known/security.txt. Archive manually so the .well-known
+      # directory is preserved, then upload as the github-pages artifact deploy-pages expects.
+      - name: Archive Pages artifact (preserve .well-known)
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --exclude=.git \
+            --exclude=.github \
+            --directory ./dist \
+            -cvf "$RUNNER_TEMP/artifact.tar" .
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: ./dist
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e


### PR DESCRIPTION
## Problem
`https://honua.io/.well-known/security.txt` returns **404** even though the file is committed and `build-dist.sh` copies it into `dist/`. The Pages page itself (security.html) is fine.

## Cause
`actions/upload-pages-artifact` archives the site with `tar … --exclude=".[^/]*"`, which **excludes every dot-directory**, dropping `.well-known/` from the published artifact. RFC 9116 requires exactly `/.well-known/security.txt`, so the path can't change.

## Fix
Archive the artifact manually (same flags **minus** the dotfile exclude) and upload it as the `github-pages` artifact that `deploy-pages` consumes.

Verified locally:
- current exclude → 0 `.well-known` entries; fixed tar → `./.well-known/security.txt` present
- `validate-workflow-pinning.sh`, `validate-lead-capture.sh`, and `build-dist.sh` all pass (new `uses:` is SHA-pinned to upload-artifact v7.0.1)

After merge + deploy, `/.well-known/security.txt` will resolve.